### PR TITLE
Display Target Level

### DIFF
--- a/Services/CanvasService.cs
+++ b/Services/CanvasService.cs
@@ -94,6 +94,7 @@ internal class CanvasService
     public static int DailyProgress = 0;
     public static int DailyGoal = 0;
     public static string DailyTarget = "";
+    public static int DailyLevel = 0;
 
     static GameObject WeeklyQuestObject;
     static LocalizedText WeeklyQuestHeader;
@@ -101,6 +102,7 @@ internal class CanvasService
     public static int WeeklyProgress = 0;
     public static int WeeklyGoal = 0;
     public static string WeeklyTarget = "";
+    public static int WeeklyLevel = 0;
 
     static readonly float ScreenWidth = Screen.width;
     static readonly float ScreenHeight = Screen.height;
@@ -186,8 +188,8 @@ internal class CanvasService
 
             if (QuestTracker)
             {
-                UpdateQuests(DailyQuestObject, DailyQuestSubHeader, DailyTarget, DailyProgress, DailyGoal);
-                UpdateQuests(WeeklyQuestObject, WeeklyQuestSubHeader, WeeklyTarget, WeeklyProgress, WeeklyGoal);
+                UpdateQuests(DailyQuestObject, DailyQuestSubHeader, DailyTarget, DailyProgress, DailyGoal, DailyLevel);
+                UpdateQuests(WeeklyQuestObject, WeeklyQuestSubHeader, WeeklyTarget, WeeklyProgress, WeeklyGoal, WeeklyLevel);
             }
 
             yield return Delay;
@@ -272,12 +274,12 @@ internal class CanvasService
             }
         }
     }
-    static void UpdateQuests(GameObject questObject, LocalizedText questSubHeader, string target, int progress, int goal)
+    static void UpdateQuests(GameObject questObject, LocalizedText questSubHeader, string target, int progress, int goal, int level)
     {
         if (progress != goal)
         {
             if (!questObject.gameObject.active) questObject.gameObject.active = true;
-            questSubHeader.ForceSet($"<color=white>{target}</color>: {progress}/<color=yellow>{goal}</color>");
+            questSubHeader.ForceSet($"<color=white>Lv{level} {target}</color>: {progress}/<color=yellow>{goal}</color>");
         }
         else
         {

--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -184,11 +184,12 @@ internal static class DataService
         public string ExpertiseType { get; set; } = ((WeaponType)int.Parse(expertiseType)).ToString();
         public List<string> BonusStats { get; set; } = Enumerable.Range(0, bonusStats.Length / 2).Select(i => ((WeaponStatType)int.Parse(bonusStats.Substring(i * 2, 2))).ToString()).ToList();
     }
-    internal class QuestData(string progress, string goal, string target)
+    internal class QuestData(string progress, string goal, string target, string level)
     {
         public int Progress { get; set; } = int.Parse(progress);
         public int Goal { get; set; } = int.Parse(goal);
         public string Target { get; set; } = target;
+        public int Level { get; set; } = int.Parse(level);
     }
     internal class  ConfigData
     {
@@ -287,8 +288,8 @@ internal static class DataService
         ExperienceData experienceData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
         LegacyData legacyData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
         ExpertiseData expertiseData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
-        QuestData dailyQuestData = new(playerData[index++], playerData[index++], playerData[index++]);
-        QuestData weeklyQuestData = new(playerData[index++], playerData[index++], playerData[index]);
+        QuestData dailyQuestData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
+        QuestData weeklyQuestData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index]);
 
         CanvasService.ExperienceProgress = experienceData.Progress;
         CanvasService.ExperienceLevel = experienceData.Level;
@@ -310,9 +311,11 @@ internal static class DataService
         CanvasService.DailyProgress = dailyQuestData.Progress;
         CanvasService.DailyGoal = dailyQuestData.Goal;
         CanvasService.DailyTarget = dailyQuestData.Target;
+        CanvasService.DailyLevel = dailyQuestData.Level;
 
         CanvasService.WeeklyProgress = weeklyQuestData.Progress;
         CanvasService.WeeklyGoal = weeklyQuestData.Goal;
         CanvasService.WeeklyTarget = weeklyQuestData.Target;
+        CanvasService.WeeklyLevel = weeklyQuestData.Level;
     }
 }


### PR DESCRIPTION
Found that sometimes quest target would not update. I figured it was seeking a specific target after it updated when I killed a roaming Lv2 Crossbow Skeleton.

Quest shows target's level