### PR TITLE
Display Target Level

### DIFF
--- a/Services/CanvasService.cs
+++ b/Services/CanvasService.cs
@@ -108,6 +108,7 @@ internal class CanvasService
     public static int DailyGoal = 0;
     public static string DailyTarget = "";
     public static bool DailyVBlood = false;
+    public static int DailyLevel = 0;
 
     static GameObject WeeklyQuestObject;
     static LocalizedText WeeklyQuestHeader;
@@ -117,6 +118,7 @@ internal class CanvasService
     public static int WeeklyGoal = 0;
     public static string WeeklyTarget = "";
     public static bool WeeklyVBlood = false;
+    public static int WeeklyLevel = 0;
 
     static readonly float ScreenWidth = Screen.width;
     static readonly float ScreenHeight = Screen.height;
@@ -203,8 +205,8 @@ internal class CanvasService
 
             if (QuestTracker)
             {
-                UpdateQuests(DailyQuestObject, DailyQuestSubHeader, DailyQuestIcon, DailyTarget, DailyProgress, DailyGoal, DailyVBlood);
-                UpdateQuests(WeeklyQuestObject, WeeklyQuestSubHeader, WeeklyQuestIcon, WeeklyTarget, WeeklyProgress, WeeklyGoal, WeeklyVBlood);
+                UpdateQuests(DailyQuestObject, DailyQuestSubHeader, DailyQuestIcon, DailyTarget, DailyProgress, DailyGoal, DailyVBlood, DailyLevel);
+                UpdateQuests(WeeklyQuestObject, WeeklyQuestSubHeader, WeeklyQuestIcon, WeeklyTarget, WeeklyProgress, WeeklyGoal, WeeklyVBlood, WeeklyLevel);
             }
 
             yield return Delay;
@@ -289,12 +291,12 @@ internal class CanvasService
             }
         }
     }
-    static void UpdateQuests(GameObject questObject, LocalizedText questSubHeader, Image questIcon, string target, int progress, int goal, bool isVBlood)
+    static void UpdateQuests(GameObject questObject, LocalizedText questSubHeader, Image questIcon, string target, int progress, int goal, bool isVBlood, int level)
     {
         if (progress != goal)
         {
             if (!questObject.gameObject.active) questObject.gameObject.active = true;
-            questSubHeader.ForceSet($"<color=white>{target}</color>: {progress}/<color=yellow>{goal}</color>");
+            questSubHeader.ForceSet($"<color=white>Lv{level} {target}</color>: {progress}/<color=yellow>{goal}</color>");
 
             if (isVBlood && questIcon.sprite.name != "BloodIcon_Cursed" && SpriteMap.TryGetValue("BloodIcon_Cursed", out Sprite vBloodSprite))
             {

--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -184,12 +184,13 @@ internal static class DataService
         public string ExpertiseType { get; set; } = ((WeaponType)int.Parse(expertiseType)).ToString();
         public List<string> BonusStats { get; set; } = Enumerable.Range(0, bonusStats.Length / 2).Select(i => ((WeaponStatType)int.Parse(bonusStats.Substring(i * 2, 2))).ToString()).ToList();
     }
-    internal class QuestData(string progress, string goal, string target, string isVBlood)
+    internal class QuestData(string progress, string goal, string target, string isVBlood, string level)
     {
         public int Progress { get; set; } = int.Parse(progress);
         public int Goal { get; set; } = int.Parse(goal);
         public string Target { get; set; } = target;
         public bool IsVBlood { get; set; } = bool.Parse(isVBlood);
+        public int Level { get; set; } = int.Parse(level);
     }
     internal class  ConfigData
     {
@@ -312,10 +313,12 @@ internal static class DataService
         CanvasService.DailyGoal = dailyQuestData.Goal;
         CanvasService.DailyTarget = dailyQuestData.Target;
         CanvasService.DailyVBlood = dailyQuestData.IsVBlood;
+        CanvasService.DailyLevel = dailyQuestData.Level;
 
         CanvasService.WeeklyProgress = weeklyQuestData.Progress;
         CanvasService.WeeklyGoal = weeklyQuestData.Goal;
         CanvasService.WeeklyTarget = weeklyQuestData.Target;
         CanvasService.WeeklyVBlood = weeklyQuestData.IsVBlood;
+        CanvasService.WeeklyLevel = weeklyQuestData.Level;
     }
 }


### PR DESCRIPTION
Quest would not update when killing Crossbow Skeletons, until I randomly killed a Lv2 Crossbow Skeleton.

- Displays quest target's level
Lv{level} {target name}