### PR TITLE
Introduce reactive element managers

### DIFF
--- a/Services/IReactiveElement.cs
+++ b/Services/IReactiveElement.cs
@@ -1,0 +1,7 @@
+namespace Eclipse.Services;
+
+internal interface IReactiveElement
+{
+    void Awake();
+    System.Collections.IEnumerator OnUpdate();
+}

--- a/Services/Managers/ExperienceManager.cs
+++ b/Services/Managers/ExperienceManager.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+
+namespace Eclipse.Services.Managers;
+
+internal class ExperienceManager : IReactiveElement
+{
+    public void Awake()
+    {
+        // Initialization logic can be expanded
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.ExperienceEnabled)
+            {
+                CanvasService.UpdateExperience();
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+}

--- a/Services/Managers/ExpertiseManager.cs
+++ b/Services/Managers/ExpertiseManager.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+
+namespace Eclipse.Services.Managers;
+
+internal class ExpertiseManager : IReactiveElement
+{
+    public void Awake()
+    {
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.ExpertiseEnabled)
+            {
+                CanvasService.UpdateExpertise();
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+}

--- a/Services/Managers/FamiliarManager.cs
+++ b/Services/Managers/FamiliarManager.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+
+namespace Eclipse.Services.Managers;
+
+internal class FamiliarManager : IReactiveElement
+{
+    public void Awake()
+    {
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.FamiliarEnabled)
+            {
+                CanvasService.UpdateFamiliar();
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+}

--- a/Services/Managers/LegacyManager.cs
+++ b/Services/Managers/LegacyManager.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+
+namespace Eclipse.Services.Managers;
+
+internal class LegacyManager : IReactiveElement
+{
+    public void Awake()
+    {
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.LegacyEnabled)
+            {
+                CanvasService.UpdateLegacy();
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+}

--- a/Services/Managers/ProfessionManager.cs
+++ b/Services/Managers/ProfessionManager.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+
+namespace Eclipse.Services.Managers;
+
+internal class ProfessionManager : IReactiveElement
+{
+    public void Awake()
+    {
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.ProfessionsEnabled)
+            {
+                CanvasService.UpdateProfessions();
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+}

--- a/Services/Managers/QuestManager.cs
+++ b/Services/Managers/QuestManager.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+
+namespace Eclipse.Services.Managers;
+
+internal class QuestManager : IReactiveElement
+{
+    public void Awake()
+    {
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.QuestsEnabled)
+            {
+                CanvasService.UpdateQuests();
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+}

--- a/Services/Managers/ShiftSlotManager.cs
+++ b/Services/Managers/ShiftSlotManager.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+
+namespace Eclipse.Services.Managers;
+
+internal class ShiftSlotManager : IReactiveElement
+{
+    public void Awake()
+    {
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.ShiftSlotEnabled)
+            {
+                CanvasService.UpdateShiftSlot();
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- define `IReactiveElement` for updatable UI elements
- add manager classes for experience, legacy, expertise, familiar, professions, quests and shift slot
- orchestrate managers from `CanvasService`
- expose update helpers and status flags

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688076a69750832dad00b0745c86e209