### PR TITLE
Eliminate CanvasUpdateLoop

### DIFF
--- a/Patches/ClientChatSystemPatch.cs
+++ b/Patches/ClientChatSystemPatch.cs
@@ -160,11 +160,7 @@ internal static class ClientChatSystemPatch
                             CanvasService._killSwitch = false;
                         }
 
-                        if (CanvasService._canvasRoutine == null)
-                        {
-                            CanvasService._canvasRoutine = CanvasService.CanvasUpdateLoop().Start();
-                            CanvasService._active = true;
-                        }
+                        CanvasService._active = true;
 
                         break;
                     case (int)NetworkEventSubType.ConfigsToClient:

--- a/Patches/InitializationPatches.cs
+++ b/Patches/InitializationPatches.cs
@@ -76,10 +76,8 @@ internal static class InitializationPatches
         CanvasService._killSwitch = true;
 
         CanvasService._shiftRoutine.Stop();
-        CanvasService._canvasRoutine.Stop();
 
         CanvasService._shiftRoutine = null;
-        CanvasService._canvasRoutine = null;
 
         CanvasService._active = false;
         CanvasService._shiftActive = false;

--- a/Services/Managers/ExperienceManager.cs
+++ b/Services/Managers/ExperienceManager.cs
@@ -6,7 +6,7 @@ internal class ExperienceManager : IReactiveElement
 {
     public void Awake()
     {
-        // Initialization logic can be expanded
+        CanvasService.InitializeExperienceBar();
     }
 
     public IEnumerator OnUpdate()

--- a/Services/Managers/ExpertiseManager.cs
+++ b/Services/Managers/ExpertiseManager.cs
@@ -6,6 +6,7 @@ internal class ExpertiseManager : IReactiveElement
 {
     public void Awake()
     {
+        CanvasService.InitializeExpertiseBar();
     }
 
     public IEnumerator OnUpdate()

--- a/Services/Managers/FamiliarManager.cs
+++ b/Services/Managers/FamiliarManager.cs
@@ -6,6 +6,7 @@ internal class FamiliarManager : IReactiveElement
 {
     public void Awake()
     {
+        CanvasService.InitializeFamiliarBar();
     }
 
     public IEnumerator OnUpdate()

--- a/Services/Managers/LegacyManager.cs
+++ b/Services/Managers/LegacyManager.cs
@@ -6,6 +6,7 @@ internal class LegacyManager : IReactiveElement
 {
     public void Awake()
     {
+        CanvasService.InitializeLegacyBar();
     }
 
     public IEnumerator OnUpdate()

--- a/Services/Managers/ProfessionManager.cs
+++ b/Services/Managers/ProfessionManager.cs
@@ -6,6 +6,7 @@ internal class ProfessionManager : IReactiveElement
 {
     public void Awake()
     {
+        CanvasService.InitializeProfessions();
     }
 
     public IEnumerator OnUpdate()

--- a/Services/Managers/QuestManager.cs
+++ b/Services/Managers/QuestManager.cs
@@ -6,6 +6,7 @@ internal class QuestManager : IReactiveElement
 {
     public void Awake()
     {
+        CanvasService.InitializeQuestTracker();
     }
 
     public IEnumerator OnUpdate()

--- a/Services/Managers/ShiftSlotManager.cs
+++ b/Services/Managers/ShiftSlotManager.cs
@@ -1,4 +1,7 @@
 using System.Collections;
+using ProjectM;
+using Eclipse;
+using Unity.Entities;
 
 namespace Eclipse.Services.Managers;
 
@@ -6,6 +9,7 @@ internal class ShiftSlotManager : IReactiveElement
 {
     public void Awake()
     {
+        CanvasService.InitializeShiftSlot();
     }
 
     public IEnumerator OnUpdate()
@@ -14,6 +18,19 @@ internal class ShiftSlotManager : IReactiveElement
         {
             if (CanvasService.ShiftSlotEnabled)
             {
+                if (!CanvasService._shiftActive && Core.LocalCharacter.TryGetComponent(out AbilityBar_Shared abilityBarShared))
+                {
+                    Entity abilityGroupEntity = abilityBarShared.CastGroup.GetEntityOnServer();
+                    if (abilityGroupEntity.TryGetComponent(out AbilityGroupState abilityGroupState) && abilityGroupState.SlotIndex == 3)
+                    {
+                        if (CanvasService._shiftRoutine == null)
+                        {
+                            CanvasService._shiftRoutine = CanvasService.ShiftUpdateLoop().Start();
+                            CanvasService._shiftActive = true;
+                        }
+                    }
+                }
+
                 CanvasService.UpdateShiftSlot();
             }
             yield return CanvasService.Delay;


### PR DESCRIPTION
## Summary
- rely on `IReactiveElement` managers for UI updates
- create initialization helpers for each UI manager
- start shift slot coroutine from `ShiftSlotManager`
- remove legacy `CanvasUpdateLoop` calls

## Testing
- `dotnet build` *(fails: Error reading resource 'Eclipse.Resources.secrets.json')*

------
https://chatgpt.com/codex/tasks/task_e_68808a65ee44832da387f715a2ef9f3b