### PR TITLE
Refactor canvas elements into reactive components

### DIFF
--- a/Services/CanvasService.cs
+++ b/Services/CanvasService.cs
@@ -315,6 +315,10 @@ internal class CanvasService
     internal static Experience Experience { get; private set; }
     internal static Legacies Legacies { get; private set; }
     internal static Professions Professions { get; private set; }
+    internal static Expertise Expertise { get; private set; }
+    internal static Familiar Familiar { get; private set; }
+    internal static Quests Quests { get; private set; }
+    internal static ShiftSlot ShiftSlot { get; private set; }
 
     internal static void SetElementState(GameObject obj, bool state)
     {
@@ -328,12 +332,12 @@ internal class CanvasService
     {
         {Element.Experience, () => Experience?.Toggle()},
         {Element.Legacy, () => Legacies?.Toggle()},
-        {Element.Expertise, ExpertiseToggle},
-        {Element.Familiars, FamiliarToggle},
+        {Element.Expertise, () => Expertise?.Toggle()},
+        {Element.Familiars, () => Familiar?.Toggle()},
         {Element.Professions, () => Professions?.Toggle()},
-        {Element.Daily, DailyQuestToggle},
-        {Element.Weekly, WeeklyQuestToggle},
-        {Element.ShiftSlot, ShiftSlotToggle}
+        {Element.Daily, () => Quests?.Toggle()},
+        {Element.Weekly, () => Quests?.Toggle()},
+        {Element.ShiftSlot, () => ShiftSlot?.Toggle()}
     };
 
     static readonly Dictionary<Element, string> _abilitySlotPaths = new()
@@ -409,6 +413,10 @@ internal class CanvasService
             Experience = new Experience();
             Legacies = new Legacies();
             Professions = new Professions();
+            Expertise = new Expertise();
+            Familiar = new Familiar();
+            Quests = new Quests();
+            ShiftSlot = new ShiftSlot();
 
             _managers.AddRange(new IReactiveElement[]
             {
@@ -593,42 +601,6 @@ internal class CanvasService
             _elementStates[gameObject] = newState;
         }
     }
-    // toggled by reactive components
-    static void ExpertiseToggle()
-    {
-        bool active = !_expertiseBarGameObject.activeSelf;
-
-        _expertiseBarGameObject.SetActive(active);
-        _elementStates[_expertiseBarGameObject] = active;
-    }
-    static void FamiliarToggle()
-    {
-        bool active = !_familiarBarGameObject.activeSelf;
-
-        _familiarBarGameObject.SetActive(active);
-        _elementStates[_familiarBarGameObject] = active;
-    }
-    static void DailyQuestToggle()
-    {
-        bool active = !_dailyQuestObject.activeSelf;
-
-        _dailyQuestObject.SetActive(active);
-        _elementStates[_dailyQuestObject] = active;
-    }
-    static void WeeklyQuestToggle()
-    {
-        bool active = !_weeklyQuestObject.activeSelf;
-
-        _weeklyQuestObject.SetActive(active);
-        _elementStates[_weeklyQuestObject] = active;
-    }
-    static void ShiftSlotToggle()
-    {
-        bool active = !_abilityDummyObject.activeSelf;
-
-        _abilityDummyObject.SetActive(active);
-        _elementStates[_abilityDummyObject] = active;
-    }
     static void InitializeBloodButton()
     {
         GameObject bloodObject = GameObject.Find(BLOOD_ORB_PATH);
@@ -654,46 +626,6 @@ internal class CanvasService
 
     // initialization moved to reactive components
 
-    internal static void InitializeExpertiseBar()
-    {
-        if (_expertiseBar)
-        {
-            ConfigureHorizontalProgressBar(ref _expertiseBarGameObject, ref _expertiseInformationPanel,
-                ref _expertiseFill, ref _expertiseText, ref _expertiseHeader, Element.Expertise, Color.grey,
-                ref _firstExpertiseStat, ref _secondExpertiseStat, ref _thirdExpertiseStat);
-        }
-    }
-
-    internal static void InitializeFamiliarBar()
-    {
-        if (_familiarBar)
-        {
-            ConfigureHorizontalProgressBar(ref _familiarBarGameObject, ref _familiarInformationPanel,
-                ref _familiarFill, ref _familiarText, ref _familiarHeader, Element.Familiars, Color.yellow,
-                ref _familiarMaxHealth, ref _familiarPhysicalPower, ref _familiarSpellPower);
-        }
-    }
-
-    internal static void InitializeQuestTracker()
-    {
-        if (_questTracker)
-        {
-            ConfigureQuestWindow(ref _dailyQuestObject, Element.Daily, Color.green, ref _dailyQuestHeader, ref _dailyQuestSubHeader, ref _dailyQuestIcon);
-            ConfigureQuestWindow(ref _weeklyQuestObject, Element.Weekly, Color.magenta, ref _weeklyQuestHeader, ref _weeklyQuestSubHeader, ref _weeklyQuestIcon);
-        }
-    }
-
-    // profession initialization handled by Professions component
-
-    internal static void InitializeShiftSlot()
-    {
-        if (_shiftSlot)
-        {
-            ConfigureShiftSlot(ref _abilityDummyObject, ref _abilityBarEntry, ref _uiState, ref _cooldownParentObject, ref _cooldownText,
-                ref _chargesTextObject, ref _cooldownFillImage, ref _chargesText, ref _chargeCooldownFillImage, ref _chargeCooldownImageObject,
-                ref _abilityEmptyIcon, ref _abilityIcon, ref _keybindObject);
-        }
-    }
     static void GetAndUpdateWeaponStatBuffer(Entity playerCharacter)
     {
         if (!playerCharacter.TryGetComponent(out Equipment equipment)) return;
@@ -1957,63 +1889,8 @@ internal class CanvasService
     // Public update helpers used by reactive managers
     // update methods moved to reactive components
 
-    public static void UpdateExpertise()
-    {
-        if (!_expertiseBar) return;
-
-        UpdateBar(_expertiseProgress, _expertiseLevel, _expertiseMaxLevel, _expertisePrestige,
-            _expertiseText, _expertiseHeader, _expertiseFill, Element.Expertise, _expertiseType);
-        UpdateWeaponStats(_expertiseBonusStats, [_firstExpertiseStat, _secondExpertiseStat, _thirdExpertiseStat], GetWeaponStatInfo);
-        GetAndUpdateWeaponStatBuffer(LocalCharacter);
-    }
-
-    public static void UpdateFamiliar()
-    {
-        if (!_familiarBar) return;
-
-        UpdateBar(_familiarProgress, _familiarLevel, _familiarMaxLevel, _familiarPrestige,
-            _familiarText, _familiarHeader, _familiarFill, Element.Familiars, _familiarName);
-        UpdateFamiliarStats(_familiarStats, [_familiarMaxHealth, _familiarPhysicalPower, _familiarSpellPower]);
-    }
 
     public static void UpdateProfessions() => Professions?.OnUpdate();
-
-    public static void UpdateQuests()
-    {
-        if (!_questTracker) return;
-
-        UpdateQuests(_dailyQuestObject, _dailyQuestSubHeader, _dailyQuestIcon, _dailyTargetType, _dailyTarget, _dailyProgress, _dailyGoal, _dailyVBlood);
-        UpdateQuests(_weeklyQuestObject, _weeklyQuestSubHeader, _weeklyQuestIcon, _weeklyTargetType, _weeklyTarget, _weeklyProgress, _weeklyGoal, _weeklyVBlood);
-    }
-
-    public static void UpdateShiftSlot()
-    {
-        if (_killSwitch || !_shiftActive) return;
-
-        if (LocalCharacter.TryGetComponent(out AbilityBar_Shared abilityBar_Shared))
-        {
-            Entity abilityGroupEntity = abilityBar_Shared.CastGroup.GetEntityOnServer();
-            Entity abilityCastEntity = abilityBar_Shared.CastAbility.GetEntityOnServer();
-
-            if (abilityGroupEntity.TryGetComponent(out AbilityGroupState abilityGroupState) && abilityGroupState.SlotIndex == 3)
-            {
-                PrefabGUID currentPrefabGUID = abilityGroupEntity.GetPrefabGUID();
-                if (TryUpdateTooltipData(abilityGroupEntity, currentPrefabGUID))
-                {
-                    UpdateAbilityData(_abilityTooltipData, abilityGroupEntity, abilityCastEntity, currentPrefabGUID);
-                }
-                else if (_abilityTooltipData != null)
-                {
-                    UpdateAbilityData(_abilityTooltipData, abilityGroupEntity, abilityCastEntity, currentPrefabGUID);
-                }
-            }
-
-            if (_abilityTooltipData != null)
-            {
-                UpdateAbilityState(abilityGroupEntity, abilityCastEntity);
-            }
-        }
-    }
     public static void ResetState()
     {
         foreach (var coroutine in _managerCoroutines)

--- a/Services/Expertise.cs
+++ b/Services/Expertise.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using ProjectM.UI;
+
+namespace Eclipse.Services;
+
+internal class Expertise : IReactiveElement
+{
+    GameObject _barGameObject;
+    GameObject _informationPanel;
+    LocalizedText _firstStat;
+    LocalizedText _secondStat;
+    LocalizedText _thirdStat;
+    LocalizedText _header;
+    LocalizedText _text;
+    Image _fill;
+
+    public void Awake()
+    {
+        if (CanvasService.ExpertiseEnabled)
+        {
+            CanvasService.ConfigureHorizontalProgressBar(ref _barGameObject, ref _informationPanel,
+                ref _fill, ref _text, ref _header, CanvasService.Element.Expertise, Color.grey,
+                ref _firstStat, ref _secondStat, ref _thirdStat);
+        }
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.ExpertiseEnabled)
+            {
+                CanvasService.UpdateBar(CanvasService._expertiseProgress, CanvasService._expertiseLevel,
+                    CanvasService._expertiseMaxLevel, CanvasService._expertisePrestige,
+                    _text, _header, _fill, CanvasService.Element.Expertise, CanvasService._expertiseType);
+                CanvasService.UpdateWeaponStats(CanvasService._expertiseBonusStats,
+                    new List<LocalizedText> { _firstStat, _secondStat, _thirdStat }, CanvasService.GetWeaponStatInfo);
+                CanvasService.GetAndUpdateWeaponStatBuffer(CanvasService.LocalCharacter);
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+
+    public void Toggle()
+    {
+        bool active = !_barGameObject.activeSelf;
+        _barGameObject.SetActive(active);
+        CanvasService.SetElementState(_barGameObject, active);
+    }
+}

--- a/Services/Familiar.cs
+++ b/Services/Familiar.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using ProjectM.UI;
+
+namespace Eclipse.Services;
+
+internal class Familiar : IReactiveElement
+{
+    GameObject _barGameObject;
+    GameObject _informationPanel;
+    LocalizedText _maxHealth;
+    LocalizedText _physicalPower;
+    LocalizedText _spellPower;
+    LocalizedText _header;
+    LocalizedText _text;
+    Image _fill;
+
+    public void Awake()
+    {
+        if (CanvasService.FamiliarEnabled)
+        {
+            CanvasService.ConfigureHorizontalProgressBar(ref _barGameObject, ref _informationPanel,
+                ref _fill, ref _text, ref _header, CanvasService.Element.Familiars, Color.yellow,
+                ref _maxHealth, ref _physicalPower, ref _spellPower);
+        }
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.FamiliarEnabled)
+            {
+                CanvasService.UpdateBar(CanvasService._familiarProgress, CanvasService._familiarLevel,
+                    CanvasService._familiarMaxLevel, CanvasService._familiarPrestige,
+                    _text, _header, _fill, CanvasService.Element.Familiars, CanvasService._familiarName);
+                CanvasService.UpdateFamiliarStats(CanvasService._familiarStats,
+                    new List<LocalizedText> { _maxHealth, _physicalPower, _spellPower });
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+
+    public void Toggle()
+    {
+        bool active = !_barGameObject.activeSelf;
+        _barGameObject.SetActive(active);
+        CanvasService.SetElementState(_barGameObject, active);
+    }
+}

--- a/Services/Managers/ExpertiseManager.cs
+++ b/Services/Managers/ExpertiseManager.cs
@@ -6,18 +6,16 @@ internal class ExpertiseManager : IReactiveElement
 {
     public void Awake()
     {
-        CanvasService.InitializeExpertiseBar();
+        CanvasService.Expertise?.Awake();
     }
 
     public IEnumerator OnUpdate()
     {
-        while (true)
+        return CanvasService.Expertise?.OnUpdate() ?? Dummy();
+
+        static IEnumerator Dummy()
         {
-            if (CanvasService.ExpertiseEnabled)
-            {
-                CanvasService.UpdateExpertise();
-            }
-            yield return CanvasService.Delay;
+            yield break;
         }
     }
 }

--- a/Services/Managers/FamiliarManager.cs
+++ b/Services/Managers/FamiliarManager.cs
@@ -6,18 +6,16 @@ internal class FamiliarManager : IReactiveElement
 {
     public void Awake()
     {
-        CanvasService.InitializeFamiliarBar();
+        CanvasService.Familiar?.Awake();
     }
 
     public IEnumerator OnUpdate()
     {
-        while (true)
+        return CanvasService.Familiar?.OnUpdate() ?? Dummy();
+
+        static IEnumerator Dummy()
         {
-            if (CanvasService.FamiliarEnabled)
-            {
-                CanvasService.UpdateFamiliar();
-            }
-            yield return CanvasService.Delay;
+            yield break;
         }
     }
 }

--- a/Services/Managers/QuestManager.cs
+++ b/Services/Managers/QuestManager.cs
@@ -6,18 +6,16 @@ internal class QuestManager : IReactiveElement
 {
     public void Awake()
     {
-        CanvasService.InitializeQuestTracker();
+        CanvasService.Quests?.Awake();
     }
 
     public IEnumerator OnUpdate()
     {
-        while (true)
+        return CanvasService.Quests?.OnUpdate() ?? Dummy();
+
+        static IEnumerator Dummy()
         {
-            if (CanvasService.QuestsEnabled)
-            {
-                CanvasService.UpdateQuests();
-            }
-            yield return CanvasService.Delay;
+            yield break;
         }
     }
 }

--- a/Services/Managers/ShiftSlotManager.cs
+++ b/Services/Managers/ShiftSlotManager.cs
@@ -10,31 +10,16 @@ internal class ShiftSlotManager : IReactiveElement
 {
     public void Awake()
     {
-        CanvasService.InitializeShiftSlot();
+        CanvasService.ShiftSlot?.Awake();
     }
 
     public IEnumerator OnUpdate()
     {
-        while (true)
-        {
-            if (CanvasService.ShiftSlotEnabled)
-            {
-                if (!CanvasService._shiftActive && Core.LocalCharacter.TryGetComponent(out AbilityBar_Shared abilityBarShared))
-                {
-                    Entity abilityGroupEntity = abilityBarShared.CastGroup.GetEntityOnServer();
-                    if (abilityGroupEntity.TryGetComponent(out AbilityGroupState abilityGroupState) && abilityGroupState.SlotIndex == 3)
-                    {
-                        if (CanvasService._shiftRoutine == null)
-                        {
-                            CanvasService._shiftRoutine = CanvasService.ShiftUpdateLoop().Start();
-                            CanvasService._shiftActive = true;
-                        }
-                    }
-                }
+        return CanvasService.ShiftSlot?.OnUpdate() ?? Dummy();
 
-                CanvasService.UpdateShiftSlot();
-            }
-            yield return CanvasService.Delay;
+        static IEnumerator Dummy()
+        {
+            yield break;
         }
     }
 }

--- a/Services/Quests.cs
+++ b/Services/Quests.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using ProjectM.UI;
+
+namespace Eclipse.Services;
+
+internal class Quests : IReactiveElement
+{
+    GameObject _dailyQuestObject;
+    LocalizedText _dailyQuestHeader;
+    LocalizedText _dailyQuestSubHeader;
+    Image _dailyQuestIcon;
+
+    GameObject _weeklyQuestObject;
+    LocalizedText _weeklyQuestHeader;
+    LocalizedText _weeklyQuestSubHeader;
+    Image _weeklyQuestIcon;
+
+    public void Awake()
+    {
+        if (CanvasService.QuestsEnabled)
+        {
+            CanvasService.ConfigureQuestWindow(ref _dailyQuestObject, CanvasService.Element.Daily, Color.green,
+                ref _dailyQuestHeader, ref _dailyQuestSubHeader, ref _dailyQuestIcon);
+            CanvasService.ConfigureQuestWindow(ref _weeklyQuestObject, CanvasService.Element.Weekly, Color.magenta,
+                ref _weeklyQuestHeader, ref _weeklyQuestSubHeader, ref _weeklyQuestIcon);
+        }
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.QuestsEnabled)
+            {
+                CanvasService.UpdateQuests(_dailyQuestObject, _dailyQuestSubHeader, _dailyQuestIcon,
+                    CanvasService._dailyTargetType, CanvasService._dailyTarget,
+                    CanvasService._dailyProgress, CanvasService._dailyGoal, CanvasService._dailyVBlood);
+                CanvasService.UpdateQuests(_weeklyQuestObject, _weeklyQuestSubHeader, _weeklyQuestIcon,
+                    CanvasService._weeklyTargetType, CanvasService._weeklyTarget,
+                    CanvasService._weeklyProgress, CanvasService._weeklyGoal, CanvasService._weeklyVBlood);
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+
+    public void Toggle()
+    {
+        bool active = !_dailyQuestObject.activeSelf;
+        _dailyQuestObject.SetActive(active);
+        _weeklyQuestObject.SetActive(active);
+        CanvasService.SetElementState(_dailyQuestObject, active);
+        CanvasService.SetElementState(_weeklyQuestObject, active);
+    }
+}

--- a/Services/ShiftSlot.cs
+++ b/Services/ShiftSlot.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using Eclipse.Utilities.Extensions;
+using ProjectM;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Eclipse.Services;
+
+internal class ShiftSlot : IReactiveElement
+{
+    public void Awake()
+    {
+        if (CanvasService.ShiftSlotEnabled)
+        {
+            CanvasService.ConfigureShiftSlot(ref CanvasService._abilityDummyObject, ref CanvasService._abilityBarEntry,
+                ref CanvasService._uiState, ref CanvasService._cooldownParentObject, ref CanvasService._cooldownText,
+                ref CanvasService._chargesTextObject, ref CanvasService._cooldownFillImage, ref CanvasService._chargesText,
+                ref CanvasService._chargeCooldownFillImage, ref CanvasService._chargeCooldownImageObject,
+                ref CanvasService._abilityEmptyIcon, ref CanvasService._abilityIcon, ref CanvasService._keybindObject);
+        }
+    }
+
+    public IEnumerator OnUpdate()
+    {
+        while (true)
+        {
+            if (CanvasService.ShiftSlotEnabled)
+            {
+                if (!CanvasService._shiftActive && Core.LocalCharacter.TryGetComponent(out AbilityBar_Shared abilityBarShared))
+                {
+                    Entity abilityGroupEntity = abilityBarShared.CastGroup.GetEntityOnServer();
+                    if (abilityGroupEntity.TryGetComponent(out AbilityGroupState abilityGroupState) && abilityGroupState.SlotIndex == 3)
+                    {
+                        if (CanvasService._shiftRoutine == null)
+                        {
+                            CanvasService._shiftRoutine = CanvasService.ShiftUpdateLoop().Start();
+                            CanvasService._shiftActive = true;
+                        }
+                    }
+                }
+
+                if (!CanvasService._killSwitch && CanvasService._shiftActive && Core.LocalCharacter.TryGetComponent(out AbilityBar_Shared bar))
+                {
+                    Entity abilityGroupEntity = bar.CastGroup.GetEntityOnServer();
+                    Entity abilityCastEntity = bar.CastAbility.GetEntityOnServer();
+
+                    if (abilityGroupEntity.TryGetComponent(out AbilityGroupState abilityGroupState) && abilityGroupState.SlotIndex == 3)
+                    {
+                        PrefabGUID currentPrefabGUID = abilityGroupEntity.GetPrefabGUID();
+                        if (CanvasService.TryUpdateTooltipData(abilityGroupEntity, currentPrefabGUID))
+                        {
+                            CanvasService.UpdateAbilityData(CanvasService._abilityTooltipData, abilityGroupEntity, abilityCastEntity, currentPrefabGUID);
+                        }
+                        else if (CanvasService._abilityTooltipData != null)
+                        {
+                            CanvasService.UpdateAbilityData(CanvasService._abilityTooltipData, abilityGroupEntity, abilityCastEntity, currentPrefabGUID);
+                        }
+                    }
+
+                    if (CanvasService._abilityTooltipData != null)
+                    {
+                        CanvasService.UpdateAbilityState(abilityGroupEntity, abilityCastEntity);
+                    }
+                }
+            }
+            yield return CanvasService.Delay;
+        }
+    }
+
+    public void Toggle()
+    {
+        bool active = !CanvasService._abilityDummyObject.activeSelf;
+        CanvasService._abilityDummyObject.SetActive(active);
+        CanvasService.SetElementState(CanvasService._abilityDummyObject, active);
+    }
+}


### PR DESCRIPTION
## Summary
- add reactive `Expertise`, `Familiar`, `Quests`, and `ShiftSlot` components
- move initialization/update logic from `CanvasService` into the new classes
- update managers to delegate to these components
- register the components during canvas initialization
- remove obsolete update helpers and toggle bindings

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68816805946c832db543566e96f3fccc