### PR TITLE
Remove obsolete professions update method

### DIFF
--- a/Services/CanvasService.cs
+++ b/Services/CanvasService.cs
@@ -1005,22 +1005,6 @@ internal class CanvasService
 
         return _abilityTooltipData != null;
     }
-    static void UpdateProfessions(float progress, int level, LocalizedText levelText, 
-        Image progressFill, Image fill, Profession profession)
-    {
-        if (_killSwitch) return;
-
-        if (level == MAX_PROFESSION_LEVEL)
-        {
-            progressFill.fillAmount = 1f;
-            fill.fillAmount = 1f;
-        }
-        else
-        {
-            progressFill.fillAmount = progress;
-            fill.fillAmount = level / MAX_PROFESSION_LEVEL;
-        }
-    }
     static void UpdateBar(float progress, int level, int maxLevel, 
         int prestiges, LocalizedText levelText, LocalizedText barHeader, 
         Image fill, Element element, string type = "")
@@ -1889,8 +1873,6 @@ internal class CanvasService
     // Public update helpers used by reactive managers
     // update methods moved to reactive components
 
-
-    public static void UpdateProfessions() => Professions?.OnUpdate();
     public static void ResetState()
     {
         foreach (var coroutine in _managerCoroutines)

--- a/Services/Professions.cs
+++ b/Services/Professions.cs
@@ -13,6 +13,7 @@ internal class Professions : IReactiveElement
     readonly Dictionary<DataService.Profession, LocalizedText> _levelTexts = new();
     readonly Dictionary<DataService.Profession, Image> _progressFills = new();
     readonly Dictionary<DataService.Profession, Image> _fillImages = new();
+    const int MAX_LEVEL = 100;
 
     public void Awake()
     {
@@ -58,7 +59,18 @@ internal class Professions : IReactiveElement
             _progressFills.TryGetValue(profession, out Image progressFill) &&
             _fillImages.TryGetValue(profession, out Image fill))
         {
-            CanvasService.UpdateProfessions(progress, level, levelText, progressFill, fill, profession);
+            if (CanvasService._killSwitch) return;
+
+            if (level == MAX_LEVEL)
+            {
+                progressFill.fillAmount = 1f;
+                fill.fillAmount = 1f;
+            }
+            else
+            {
+                progressFill.fillAmount = progress;
+                fill.fillAmount = level / (float)MAX_LEVEL;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- delete unused `CanvasService.UpdateProfessions` API
- use local logic inside `Professions` for UI updates
- rely on `ProfessionManager` coroutine for updates

## Testing
- `dotnet build -c Release` *(fails: unable to reach nuget.bepinex.dev)*

------
https://chatgpt.com/codex/tasks/task_e_68816c443390832dade469329795ebf0