### PR TITLE
Introduce state objects for experience and legacy

### DIFF
--- a/Services/CanvasService.cs
+++ b/Services/CanvasService.cs
@@ -16,6 +16,7 @@ using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using Eclipse.Utilities.Extensions;
+using Eclipse.States;
 using static Eclipse.Services.DataService;
 using static Eclipse.Utilities.GameObjects;
 using static UnityEngine.Rendering.HighDefinition.HDCachedShadowAtlas;
@@ -162,20 +163,8 @@ internal class CanvasService
     static Canvas _targetInfoPanelCanvas;
     public static string _version = string.Empty;
 
-    // moved to Experience component
-    public static float _experienceProgress = 0f;
-    public static int _experienceLevel = 0;
-    public static int _experiencePrestige = 0;
-    public static int _experienceMaxLevel = 90;
-    public static PlayerClass _classType = PlayerClass.None;
-
-    // moved to Legacies component
-    public static string _legacyType;
-    public static float _legacyProgress = 0f;
-    public static int _legacyLevel = 0;
-    public static int _legacyPrestige = 0;
-    public static int _legacyMaxLevel = 100;
-    public static List<string> _legacyBonusStats = ["", "", ""];
+    internal static ExperienceState ExperienceState => DataService.Experience;
+    internal static LegacyState LegacyState => DataService.Legacy;
 
     static GameObject _expertiseBarGameObject;
     static GameObject _expertiseInformationPanel;
@@ -410,8 +399,8 @@ internal class CanvasService
 
         try
         {
-            Experience = new Experience();
-            Legacies = new Legacies();
+            Experience = new Experience(DataService.Experience);
+            Legacies = new Legacies(DataService.Legacy);
             Professions = new Professions();
             Expertise = new Expertise();
             Familiar = new Familiar();
@@ -1152,7 +1141,7 @@ internal class CanvasService
         {
             if (_weaponStatValues.TryGetValue(weaponStat, out float statValue))
             {
-                float classMultiplier = ClassSynergy(weaponStat, _classType, _classStatSynergies);
+                float classMultiplier = ClassSynergy(weaponStat, ExperienceState.Class, _classStatSynergies);
                 statValue *= (1 + _prestigeStatMultiplier * _expertisePrestige) * classMultiplier * ((float)_expertiseLevel / _expertiseMaxLevel);
                 float displayStatValue = statValue;
                 int statModificationId = ModificationIds.GenerateId(0, (int)weaponStat, statValue);
@@ -1197,8 +1186,8 @@ internal class CanvasService
         {
             if (_bloodStatValues.TryGetValue(bloodStat, out float statValue))
             {
-                float classMultiplier = ClassSynergy(bloodStat, _classType, _classStatSynergies);
-                statValue *= (1 + _prestigeStatMultiplier * _legacyPrestige) * classMultiplier * ((float)_legacyLevel / _legacyMaxLevel);
+                float classMultiplier = ClassSynergy(bloodStat, ExperienceState.Class, _classStatSynergies);
+                statValue *= (1 + _prestigeStatMultiplier * LegacyState.Prestige) * classMultiplier * ((float)LegacyState.Level / LegacyState.MaxLevel);
                 string displayString = $"<color=#00FFFF>{BloodStatTypeAbbreviations[bloodStat]}</color>: <color=#90EE90>{(statValue * 100).ToString("F0") + "%"}</color>";
 
                 int statModificationId = ModificationIds.GenerateId(1, (int)bloodStat, statValue);

--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -4,7 +4,7 @@ using System.IO;
 using Eclipse.DTOs;
 using UnityEngine;
 using Eclipse.Utilities.Extensions;
-using static Eclipse.Services.CanvasService;
+using Eclipse.States;
 
 namespace Eclipse.Services;
 internal static class DataService
@@ -13,6 +13,9 @@ internal static class DataService
 
     public static void UseJsonParser() => Parser = new JsonDataParser();
     public static void UseLegacyParser() => Parser = new LegacyDataParser();
+
+    internal static ExperienceState Experience { get; } = new();
+    internal static LegacyState Legacy { get; } = new();
 
     [Flags]
     public enum ReservedFlags : int
@@ -415,8 +418,8 @@ internal static class DataService
             _prestigeStatMultiplier = parsedConfigData.PrestigeStatMultiplier;
             _classStatMultiplier = parsedConfigData.ClassStatMultiplier;
 
-            _experienceMaxLevel = parsedConfigData.MaxPlayerLevel;
-            _legacyMaxLevel = parsedConfigData.MaxLegacyLevel;
+            Experience.MaxLevel = parsedConfigData.MaxPlayerLevel;
+            Legacy.MaxLevel = parsedConfigData.MaxLegacyLevel;
             _expertiseMaxLevel = parsedConfigData.MaxExpertiseLevel;
             _familiarMaxLevel = parsedConfigData.MaxFamiliarLevel;
 
@@ -457,16 +460,16 @@ internal static class DataService
         QuestData dailyQuestData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
         QuestData weeklyQuestData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
 
-        _experienceProgress = experienceData.Progress;
-        _experienceLevel = experienceData.Level;
-        _experiencePrestige = experienceData.Prestige;
-        _classType = experienceData.Class;
+        Experience.Progress = experienceData.Progress;
+        Experience.Level = experienceData.Level;
+        Experience.Prestige = experienceData.Prestige;
+        Experience.Class = experienceData.Class;
 
-        _legacyProgress = legacyData.Progress;
-        _legacyLevel = legacyData.Level;
-        _legacyPrestige = legacyData.Prestige;
-        _legacyType = legacyData.LegacyType;
-        _legacyBonusStats = legacyData.BonusStats;
+        Legacy.Progress = legacyData.Progress;
+        Legacy.Level = legacyData.Level;
+        Legacy.Prestige = legacyData.Prestige;
+        Legacy.LegacyType = legacyData.LegacyType;
+        Legacy.BonusStats = legacyData.BonusStats;
 
         _expertiseProgress = expertiseData.Progress;
         _expertiseLevel = expertiseData.Level;
@@ -516,8 +519,8 @@ internal static class DataService
     {
         _prestigeStatMultiplier = dto.PrestigeStatMultiplier;
         _classStatMultiplier = dto.ClassStatMultiplier;
-        _experienceMaxLevel = dto.MaxPlayerLevel;
-        _legacyMaxLevel = dto.MaxLegacyLevel;
+        Experience.MaxLevel = dto.MaxPlayerLevel;
+        Legacy.MaxLevel = dto.MaxLegacyLevel;
         _expertiseMaxLevel = dto.MaxExpertiseLevel;
         _familiarMaxLevel = dto.MaxFamiliarLevel;
         _reservedFlags = (ReservedFlags)dto.ReservedFlags;
@@ -539,17 +542,17 @@ internal static class DataService
     public static void ApplyPlayerDto(PlayerDataDto dto)
     {
         var exp = dto.Experience;
-        _experienceProgress = exp.Progress;
-        _experienceLevel = exp.Level;
-        _experiencePrestige = exp.Prestige;
-        _classType = exp.Class;
+        Experience.Progress = exp.Progress;
+        Experience.Level = exp.Level;
+        Experience.Prestige = exp.Prestige;
+        Experience.Class = exp.Class;
 
         var leg = dto.Legacy;
-        _legacyProgress = leg.Progress;
-        _legacyLevel = leg.Level;
-        _legacyPrestige = leg.Prestige;
-        _legacyType = leg.LegacyType;
-        _legacyBonusStats = leg.BonusStats;
+        Legacy.Progress = leg.Progress;
+        Legacy.Level = leg.Level;
+        Legacy.Prestige = leg.Prestige;
+        Legacy.LegacyType = leg.LegacyType;
+        Legacy.BonusStats = leg.BonusStats;
 
         var ex2 = dto.Expertise;
         _expertiseProgress = ex2.Progress;

--- a/Services/Experience.cs
+++ b/Services/Experience.cs
@@ -2,11 +2,13 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
 using ProjectM.UI;
+using Eclipse.States;
 
 namespace Eclipse.Services;
 
 internal class Experience : IReactiveElement
 {
+    readonly ExperienceState _state;
     GameObject _barGameObject;
     GameObject _informationPanel;
     LocalizedText _header;
@@ -15,6 +17,11 @@ internal class Experience : IReactiveElement
     LocalizedText _classText;
     LocalizedText _secondText;
     Image _fill;
+
+    public Experience(ExperienceState state)
+    {
+        _state = state;
+    }
 
     public void Awake()
     {
@@ -32,10 +39,10 @@ internal class Experience : IReactiveElement
         {
             if (CanvasService.ExperienceEnabled)
             {
-                CanvasService.UpdateBar(CanvasService._experienceProgress, CanvasService._experienceLevel,
-                    CanvasService._experienceMaxLevel, CanvasService._experiencePrestige,
+                CanvasService.UpdateBar(_state.Progress, _state.Level,
+                    _state.MaxLevel, _state.Prestige,
                     _text, _header, _fill, CanvasService.Element.Experience);
-                CanvasService.UpdateClass(CanvasService._classType, _classText);
+                CanvasService.UpdateClass(_state.Class, _classText);
             }
             yield return CanvasService.Delay;
         }

--- a/Services/Legacies.cs
+++ b/Services/Legacies.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using ProjectM.UI;
+using Eclipse.States;
 
 namespace Eclipse.Services;
 
 internal class Legacies : IReactiveElement
 {
+    readonly LegacyState _state;
     GameObject _barGameObject;
     GameObject _informationPanel;
     LocalizedText _firstStat;
@@ -16,6 +18,11 @@ internal class Legacies : IReactiveElement
     LocalizedText _header;
     LocalizedText _text;
     Image _fill;
+
+    public Legacies(LegacyState state)
+    {
+        _state = state;
+    }
 
     public void Awake()
     {
@@ -33,10 +40,10 @@ internal class Legacies : IReactiveElement
         {
             if (CanvasService.LegacyEnabled)
             {
-                CanvasService.UpdateBar(CanvasService._legacyProgress, CanvasService._legacyLevel,
-                    CanvasService._legacyMaxLevel, CanvasService._legacyPrestige,
-                    _text, _header, _fill, CanvasService.Element.Legacy, CanvasService._legacyType);
-                CanvasService.UpdateBloodStats(CanvasService._legacyBonusStats,
+                CanvasService.UpdateBar(_state.Progress, _state.Level,
+                    _state.MaxLevel, _state.Prestige,
+                    _text, _header, _fill, CanvasService.Element.Legacy, _state.LegacyType);
+                CanvasService.UpdateBloodStats(_state.BonusStats,
                     new List<LocalizedText> { _firstStat, _secondStat, _thirdStat }, CanvasService.GetBloodStatInfo);
             }
             yield return CanvasService.Delay;

--- a/States/ExperienceState.cs
+++ b/States/ExperienceState.cs
@@ -1,0 +1,12 @@
+using Eclipse.Services;
+
+namespace Eclipse.States;
+
+internal class ExperienceState
+{
+    internal float Progress { get; set; }
+    internal int Level { get; set; }
+    internal int Prestige { get; set; }
+    internal DataService.PlayerClass Class { get; set; }
+    internal int MaxLevel { get; set; }
+}

--- a/States/LegacyState.cs
+++ b/States/LegacyState.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Eclipse.Services;
+
+namespace Eclipse.States;
+
+internal class LegacyState : ExperienceState
+{
+    internal string LegacyType { get; set; } = string.Empty;
+    internal List<string> BonusStats { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
- implement `ExperienceState` and `LegacyState`
- store state in `DataService` and expose via `CanvasService`
- pass state objects to `Experience` and `Legacies` components
- update data parsing and UI updates to use the new state

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-6.0` *(fails: package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68818289f22c832d9a353600367ba083