### PR TITLE
Add state classes for various UI features

### DIFF
--- a/States/ExpertiseState.cs
+++ b/States/ExpertiseState.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Eclipse.States;
+
+internal class ExpertiseState
+{
+    internal string ExpertiseType { get; set; } = string.Empty;
+    internal float Progress { get; set; }
+    internal int Level { get; set; }
+    internal int Prestige { get; set; }
+    internal int MaxLevel { get; set; } = 100;
+    internal List<string> BonusStats { get; set; } = new() { "", "", "" };
+}

--- a/States/FamiliarState.cs
+++ b/States/FamiliarState.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Eclipse.States;
+
+internal class FamiliarState
+{
+    internal float Progress { get; set; }
+    internal int Level { get; set; } = 1;
+    internal int Prestige { get; set; }
+    internal int MaxLevel { get; set; } = 90;
+    internal string Name { get; set; } = string.Empty;
+    internal List<string> Stats { get; set; } = new() { "", "", "" };
+}

--- a/States/ProfessionsState.cs
+++ b/States/ProfessionsState.cs
@@ -1,0 +1,30 @@
+namespace Eclipse.States;
+
+internal class ProfessionsState
+{
+    internal bool EquipmentBonus { get; set; }
+
+    internal float EnchantingProgress { get; set; }
+    internal int EnchantingLevel { get; set; }
+
+    internal float AlchemyProgress { get; set; }
+    internal int AlchemyLevel { get; set; }
+
+    internal float HarvestingProgress { get; set; }
+    internal int HarvestingLevel { get; set; }
+
+    internal float BlacksmithingProgress { get; set; }
+    internal int BlacksmithingLevel { get; set; }
+
+    internal float TailoringProgress { get; set; }
+    internal int TailoringLevel { get; set; }
+
+    internal float WoodcuttingProgress { get; set; }
+    internal int WoodcuttingLevel { get; set; }
+
+    internal float MiningProgress { get; set; }
+    internal int MiningLevel { get; set; }
+
+    internal float FishingProgress { get; set; }
+    internal int FishingLevel { get; set; }
+}

--- a/States/QuestState.cs
+++ b/States/QuestState.cs
@@ -1,0 +1,18 @@
+using Eclipse.Services;
+
+namespace Eclipse.States;
+
+internal class QuestState
+{
+    internal DataService.TargetType DailyTargetType { get; set; } = DataService.TargetType.Kill;
+    internal int DailyProgress { get; set; }
+    internal int DailyGoal { get; set; }
+    internal string DailyTarget { get; set; } = string.Empty;
+    internal bool DailyVBlood { get; set; }
+
+    internal DataService.TargetType WeeklyTargetType { get; set; } = DataService.TargetType.Kill;
+    internal int WeeklyProgress { get; set; }
+    internal int WeeklyGoal { get; set; }
+    internal string WeeklyTarget { get; set; } = string.Empty;
+    internal bool WeeklyVBlood { get; set; }
+}

--- a/States/ShiftSlotState.cs
+++ b/States/ShiftSlotState.cs
@@ -1,0 +1,39 @@
+using ProjectM;
+using ProjectM.UI;
+using TMPro;
+using UnityEngine;
+
+namespace Eclipse.States;
+
+internal class ShiftSlotState
+{
+    internal PrefabGUID AbilityGroupPrefabGuid { get; set; }
+    internal AbilityTooltipData? AbilityTooltipData { get; set; }
+
+    internal GameObject AbilityDummyObject { get; set; }
+    internal AbilityBarEntry AbilityBarEntry { get; set; }
+    internal AbilityBarEntry.UIState UiState { get; set; }
+
+    internal GameObject CooldownParentObject { get; set; }
+    internal TextMeshProUGUI CooldownText { get; set; }
+    internal GameObject ChargeCooldownImageObject { get; set; }
+    internal GameObject ChargesTextObject { get; set; }
+    internal TextMeshProUGUI ChargesText { get; set; }
+    internal Image CooldownFillImage { get; set; }
+    internal Image ChargeCooldownFillImage { get; set; }
+
+    internal GameObject AbilityEmptyIcon { get; set; }
+    internal GameObject AbilityIcon { get; set; }
+    internal GameObject KeybindObject { get; set; }
+
+    internal int ShiftSpellIndex { get; set; } = -1;
+    internal double CooldownEndTime { get; set; }
+    internal float CooldownRemaining { get; set; }
+    internal float CooldownTime { get; set; }
+    internal int CurrentCharges { get; set; }
+    internal int MaxCharges { get; set; }
+    internal double ChargeUpEndTime { get; set; }
+    internal float ChargeUpTime { get; set; }
+    internal float ChargeUpTimeRemaining { get; set; }
+    internal float ChargeCooldownTime { get; set; }
+}


### PR DESCRIPTION
## Summary
- add ExpertiseState to track expertise info
- add FamiliarState for familiar progress
- add ProfessionsState for profession levels
- add QuestState for daily and weekly quests
- add ShiftSlotState for shift ability info

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818e9e2450832d8161cc7ac150cabb