### PR TITLE
Expose additional state objects

### DIFF
--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -16,6 +16,11 @@ internal static class DataService
 
     internal static ExperienceState Experience { get; } = new();
     internal static LegacyState Legacy { get; } = new();
+    internal static ExpertiseState Expertise { get; } = new();
+    internal static FamiliarState Familiar { get; } = new();
+    internal static ProfessionsState Professions { get; } = new();
+    internal static QuestState Quests { get; } = new();
+    internal static ShiftSlotState ShiftSlot { get; } = new();
 
     [Flags]
     public enum ReservedFlags : int


### PR DESCRIPTION
## Summary
- expose more internal state objects as properties on `DataService`
- these are initialized when `DataService` loads just like `Experience` and `Legacy`

## Testing
- `dotnet build -c Release` *(fails: unable to download packages from nuget.bepinex.dev)*

------
https://chatgpt.com/codex/tasks/task_e_6881959605b0832d8c600c8af1b24769