### PR TITLE
Rename experience to leveling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - removed unneeded dependency like I meant to for 1.1.1, oopsie
 
 `1.1.1`
-- class text under experience bar formatted more aesthetically
+- class text under leveling bar formatted more aesthetically
 - improved positioning for UI elements at various resolutions (probably >_>)
 
 `1.0.0`

--- a/DTOs/PlayerDataDto.cs
+++ b/DTOs/PlayerDataDto.cs
@@ -5,7 +5,7 @@ namespace Eclipse.DTOs;
 
 internal class PlayerDataDto
 {
-    internal ExperienceDto Experience { get; set; } = new();
+    internal LevelingDto Leveling { get; set; } = new();
     internal LegacyDto Legacy { get; set; } = new();
     internal ExpertiseDto Expertise { get; set; } = new();
     internal FamiliarDto Familiar { get; set; } = new();
@@ -15,7 +15,7 @@ internal class PlayerDataDto
     internal int ShiftSpellIndex { get; set; }
 }
 
-internal class ExperienceDto
+internal class LevelingDto
 {
     internal float Progress { get; set; }
     internal int Level { get; set; }
@@ -23,13 +23,13 @@ internal class ExperienceDto
     internal DataService.PlayerClass Class { get; set; }
 }
 
-internal class LegacyDto : ExperienceDto
+internal class LegacyDto : LevelingDto
 {
     internal string LegacyType { get; set; } = string.Empty;
     internal List<string> BonusStats { get; set; } = new();
 }
 
-internal class ExpertiseDto : ExperienceDto
+internal class ExpertiseDto : LevelingDto
 {
     internal string ExpertiseType { get; set; } = string.Empty;
     internal List<string> BonusStats { get; set; } = new();

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -61,8 +61,8 @@ internal class Plugin : BasePlugin
         }
         */
 
-        _leveling = InitConfigEntry("UIOptions", "ExperienceBar", true, "Enable/Disable the experience bar, requires both ClientCompanion/LevelingSystem to be enabled in Bloodcraft.");
-        _prestige = InitConfigEntry("UIOptions", "ShowPrestige", true, "Enable/Disable showing prestige level in front of experience bar, requires both ClientCompanion/PrestigeSystem to be enabled in Bloodcraft.");
+        _leveling = InitConfigEntry("UIOptions", "ExperienceBar", true, "Enable/Disable the leveling bar, requires both ClientCompanion/LevelingSystem to be enabled in Bloodcraft.");
+        _prestige = InitConfigEntry("UIOptions", "ShowPrestige", true, "Enable/Disable showing prestige level in front of the leveling bar, requires both ClientCompanion/PrestigeSystem to be enabled in Bloodcraft.");
         _legacies = InitConfigEntry("UIOptions", "LegacyBar", true, "Enable/Disable the legacy bar, requires both ClientCompanion/BloodSystem to be enabled in Bloodcraft.");
         _expertise = InitConfigEntry("UIOptions", "ExpertiseBar", true, "Enable/Disable the expertise bar, requires both ClientCompanion/ExpertiseSystem to be enabled in Bloodcraft.");
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Jairon O.; Odjit; Jera; Kokuren TCG and Gaming Shop; Rexxn; Eduardo G.; DirtyMik
 
 ### UIOptions
 
-- **Experience Bar**: `ExperienceBar` (bool, default: true)  
-  Enable or disable the experience bar.
+- **Leveling Bar**: `ExperienceBar` (bool, default: true)
+  Enable or disable the leveling bar.
 - **Show Prestige**: `ShowPrestige` (bool, default: true)  
   Enable or disable showing prestige levels.
 - **Legacy Bar**: `LegacyBar` (bool, default: true)  

--- a/Services/CanvasService.cs
+++ b/Services/CanvasService.cs
@@ -30,7 +30,7 @@ internal class CanvasService
     static ManagedDataRegistry ManagedDataRegistry => SystemService.ManagedDataSystem.ManagedDataRegistry;
     static Entity LocalCharacter => Core.LocalCharacter;
 
-    static readonly bool _experienceBar = Plugin.Leveling;
+    static readonly bool _levelingBar = Plugin.Leveling;
     static readonly bool _showPrestige = Plugin.Prestige;
     static readonly bool _legacyBar = Plugin.Legacies;
     static readonly bool _expertiseBar = Plugin.Expertise;
@@ -39,7 +39,7 @@ internal class CanvasService
     static readonly bool _questTracker = Plugin.Quests;
     static readonly bool _shiftSlot = Plugin.ShiftSlot;
 
-    public static bool ExperienceEnabled => _experienceBar;
+    public static bool LevelingEnabled => _levelingBar;
     public static bool LegacyEnabled => _legacyBar;
     public static bool ExpertiseEnabled => _expertiseBar;
     public static bool FamiliarEnabled => _familiarBar;
@@ -48,7 +48,7 @@ internal class CanvasService
     public static bool ShiftSlotEnabled => _shiftSlot;
     public enum Element
     {
-        Experience,
+        Leveling,
         Legacy,
         Expertise,
         Familiars,
@@ -163,7 +163,7 @@ internal class CanvasService
     static Canvas _targetInfoPanelCanvas;
     public static string _version = string.Empty;
 
-    internal static ExperienceState ExperienceState => DataService.Experience;
+    internal static LevelingState LevelingState => DataService.Leveling;
     internal static LegacyState LegacyState => DataService.Legacy;
 
     static GameObject _expertiseBarGameObject;
@@ -301,7 +301,7 @@ internal class CanvasService
     static readonly Dictionary<GameObject, bool> _elementStates = [];
     static readonly List<GameObject> _professionElements = [];
 
-    internal static Experience Experience { get; private set; }
+    internal static Leveling Leveling { get; private set; }
     internal static Legacies Legacies { get; private set; }
     internal static Professions Professions { get; private set; }
     internal static Expertise Expertise { get; private set; }
@@ -319,7 +319,7 @@ internal class CanvasService
 
     static readonly Dictionary<Element, Action> _abilitySlotToggles = new()
     {
-        {Element.Experience, () => Experience?.Toggle()},
+        {Element.Leveling, () => Leveling?.Toggle()},
         {Element.Legacy, () => Legacies?.Toggle()},
         {Element.Expertise, () => Expertise?.Toggle()},
         {Element.Familiars, () => Familiar?.Toggle()},
@@ -331,7 +331,7 @@ internal class CanvasService
 
     static readonly Dictionary<Element, string> _abilitySlotPaths = new()
     {
-        { Element.Experience, "HUDCanvas(Clone)/BottomBarCanvas/BottomBar(Clone)/Content/Background/AbilityBar/AbilityBarEntry_Primary/" },
+        { Element.Leveling, "HUDCanvas(Clone)/BottomBarCanvas/BottomBar(Clone)/Content/Background/AbilityBar/AbilityBarEntry_Primary/" },
         { Element.Legacy, "HUDCanvas(Clone)/BottomBarCanvas/BottomBar(Clone)/Content/Background/AbilityBar/AbilityBarEntry_WeaponSkill1/" },
         { Element.Expertise, "HUDCanvas(Clone)/BottomBarCanvas/BottomBar(Clone)/Content/Background/AbilityBar/AbilityBarEntry_WeaponSkill2/" },
         { Element.Familiars, "HUDCanvas(Clone)/BottomBarCanvas/BottomBar(Clone)/Content/Background/AbilityBar/AbilityBarEntry_Travel/" },
@@ -342,7 +342,7 @@ internal class CanvasService
 
     static readonly Dictionary<Element, bool> _activeElements = new()
     {
-        { Element.Experience, _experienceBar },
+        { Element.Leveling, _levelingBar },
         { Element.Legacy, _legacyBar },
         { Element.Expertise, _expertiseBar },
         { Element.Familiars, _familiarBar },
@@ -399,7 +399,7 @@ internal class CanvasService
 
         try
         {
-            Experience = new Experience(DataService.Experience);
+            Leveling = new Leveling(DataService.Leveling);
             Legacies = new Legacies(DataService.Legacy);
             Professions = new Professions();
             Expertise = new Expertise();
@@ -409,7 +409,7 @@ internal class CanvasService
 
             _managers.AddRange(new IReactiveElement[]
             {
-                new Managers.ExperienceManager(),
+                new Managers.LevelingManager(),
                 new Managers.LegacyManager(),
                 new Managers.ExpertiseManager(),
                 new Managers.FamiliarManager(),
@@ -1035,7 +1035,7 @@ internal class CanvasService
         {
             string header = "";
 
-            if (element.Equals(Element.Experience))
+            if (element.Equals(Element.Leveling))
             {
                 header = $"{element} {IntegerToRoman(prestiges)}";
             }
@@ -1141,7 +1141,7 @@ internal class CanvasService
         {
             if (_weaponStatValues.TryGetValue(weaponStat, out float statValue))
             {
-                float classMultiplier = ClassSynergy(weaponStat, ExperienceState.Class, _classStatSynergies);
+                float classMultiplier = ClassSynergy(weaponStat, LevelingState.Class, _classStatSynergies);
                 statValue *= (1 + _prestigeStatMultiplier * _expertisePrestige) * classMultiplier * ((float)_expertiseLevel / _expertiseMaxLevel);
                 float displayStatValue = statValue;
                 int statModificationId = ModificationIds.GenerateId(0, (int)weaponStat, statValue);
@@ -1186,7 +1186,7 @@ internal class CanvasService
         {
             if (_bloodStatValues.TryGetValue(bloodStat, out float statValue))
             {
-                float classMultiplier = ClassSynergy(bloodStat, ExperienceState.Class, _classStatSynergies);
+                float classMultiplier = ClassSynergy(bloodStat, LevelingState.Class, _classStatSynergies);
                 statValue *= (1 + _prestigeStatMultiplier * LegacyState.Prestige) * classMultiplier * ((float)LegacyState.Level / LegacyState.MaxLevel);
                 string displayString = $"<color=#00FFFF>{BloodStatTypeAbbreviations[bloodStat]}</color>: <color=#90EE90>{(statValue * 100).ToString("F0") + "%"}</color>";
 
@@ -1719,15 +1719,15 @@ internal class CanvasService
     {
         switch (element)
         {
-            case Element.Experience:
-                ConfigureExperiencePanel(ref informationPanelObject, ref firstText, ref secondText, ref thirdText);
+            case Element.Leveling:
+                ConfigureLevelingPanel(ref informationPanelObject, ref firstText, ref secondText, ref thirdText);
                 break;
             default:
                 ConfigureDefaultPanel(ref informationPanelObject, ref firstText, ref secondText, ref thirdText);
                 break;
         }
     }
-    static void ConfigureExperiencePanel(ref GameObject panel, ref LocalizedText firstText, ref LocalizedText secondText, 
+    static void ConfigureLevelingPanel(ref GameObject panel, ref LocalizedText firstText, ref LocalizedText secondText,
         ref LocalizedText thirdText)
     {
         RectTransform panelTransform = panel.GetComponent<RectTransform>();

--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -14,7 +14,7 @@ internal static class DataService
     public static void UseJsonParser() => Parser = new JsonDataParser();
     public static void UseLegacyParser() => Parser = new LegacyDataParser();
 
-    internal static ExperienceState Experience { get; } = new();
+    internal static LevelingState Leveling { get; } = new();
     internal static LegacyState Legacy { get; } = new();
     internal static ExpertiseState Expertise { get; } = new();
     internal static FamiliarState Familiar { get; } = new();
@@ -271,19 +271,19 @@ internal static class DataService
         public float FishingProgress { get; set; } = float.Parse(fishingProgress, CultureInfo.InvariantCulture) / 100f;
         public int FishingLevel { get; set; } = int.Parse(fishingLevel, CultureInfo.InvariantCulture);
     }
-    public class ExperienceData(string percent, string level, string prestige, string playerClass)
+    public class LevelingData(string percent, string level, string prestige, string playerClass)
     {
         public float Progress { get; set; } = float.Parse(percent, CultureInfo.InvariantCulture) / 100f;
         public int Level { get; set; } = int.Parse(level, CultureInfo.InvariantCulture);
         public int Prestige { get; set; } = int.Parse(prestige, CultureInfo.InvariantCulture);
         public PlayerClass Class { get; set; } = (PlayerClass)int.Parse(playerClass, CultureInfo.InvariantCulture);
     }
-    public class LegacyData(string percent, string level, string prestige, string legacyType, string bonusStats) : ExperienceData(percent, level, prestige, legacyType)
+    public class LegacyData(string percent, string level, string prestige, string legacyType, string bonusStats) : LevelingData(percent, level, prestige, legacyType)
     {
         public string LegacyType { get; set; } = ((BloodType)int.Parse(legacyType, CultureInfo.InvariantCulture)).ToString();
         public List<string> BonusStats { get; set; } = [..Enumerable.Range(0, bonusStats.Length / 2).Select(i => ((BloodStatType)int.Parse(bonusStats.Substring(i * 2, 2), CultureInfo.InvariantCulture)).ToString())];
     }
-    public class ExpertiseData(string percent, string level, string prestige, string expertiseType, string bonusStats) : ExperienceData(percent, level, prestige, expertiseType)
+    public class ExpertiseData(string percent, string level, string prestige, string expertiseType, string bonusStats) : LevelingData(percent, level, prestige, expertiseType)
     {
         public string ExpertiseType { get; set; } = ((WeaponType)int.Parse(expertiseType)).ToString();
         public List<string> BonusStats { get; set; } = [..Enumerable.Range(0, bonusStats.Length / 2).Select(i => ((WeaponStatType)int.Parse(bonusStats.Substring(i * 2, 2), CultureInfo.InvariantCulture)).ToString())];
@@ -423,7 +423,7 @@ internal static class DataService
             _prestigeStatMultiplier = parsedConfigData.PrestigeStatMultiplier;
             _classStatMultiplier = parsedConfigData.ClassStatMultiplier;
 
-            Experience.MaxLevel = parsedConfigData.MaxPlayerLevel;
+            Leveling.MaxLevel = parsedConfigData.MaxPlayerLevel;
             Legacy.MaxLevel = parsedConfigData.MaxLegacyLevel;
             _expertiseMaxLevel = parsedConfigData.MaxExpertiseLevel;
             _familiarMaxLevel = parsedConfigData.MaxFamiliarLevel;
@@ -457,7 +457,7 @@ internal static class DataService
     {
         int index = 0;
 
-        ExperienceData experienceData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
+        LevelingData levelingData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
         LegacyData legacyData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
         ExpertiseData expertiseData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
         FamiliarData familiarData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
@@ -465,10 +465,10 @@ internal static class DataService
         QuestData dailyQuestData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
         QuestData weeklyQuestData = new(playerData[index++], playerData[index++], playerData[index++], playerData[index++], playerData[index++]);
 
-        Experience.Progress = experienceData.Progress;
-        Experience.Level = experienceData.Level;
-        Experience.Prestige = experienceData.Prestige;
-        Experience.Class = experienceData.Class;
+        Leveling.Progress = levelingData.Progress;
+        Leveling.Level = levelingData.Level;
+        Leveling.Prestige = levelingData.Prestige;
+        Leveling.Class = levelingData.Class;
 
         Legacy.Progress = legacyData.Progress;
         Legacy.Level = legacyData.Level;
@@ -524,7 +524,7 @@ internal static class DataService
     {
         _prestigeStatMultiplier = dto.PrestigeStatMultiplier;
         _classStatMultiplier = dto.ClassStatMultiplier;
-        Experience.MaxLevel = dto.MaxPlayerLevel;
+        Leveling.MaxLevel = dto.MaxPlayerLevel;
         Legacy.MaxLevel = dto.MaxLegacyLevel;
         _expertiseMaxLevel = dto.MaxExpertiseLevel;
         _familiarMaxLevel = dto.MaxFamiliarLevel;
@@ -546,11 +546,11 @@ internal static class DataService
 
     public static void ApplyPlayerDto(PlayerDataDto dto)
     {
-        var exp = dto.Experience;
-        Experience.Progress = exp.Progress;
-        Experience.Level = exp.Level;
-        Experience.Prestige = exp.Prestige;
-        Experience.Class = exp.Class;
+        var lvl = dto.Leveling;
+        Leveling.Progress = lvl.Progress;
+        Leveling.Level = lvl.Level;
+        Leveling.Prestige = lvl.Prestige;
+        Leveling.Class = lvl.Class;
 
         var leg = dto.Legacy;
         Legacy.Progress = leg.Progress;

--- a/Services/Leveling.cs
+++ b/Services/Leveling.cs
@@ -6,9 +6,9 @@ using Eclipse.States;
 
 namespace Eclipse.Services;
 
-internal class Experience : IReactiveElement
+internal class Leveling : IReactiveElement
 {
-    readonly ExperienceState _state;
+    readonly LevelingState _state;
     GameObject _barGameObject;
     GameObject _informationPanel;
     LocalizedText _header;
@@ -18,17 +18,17 @@ internal class Experience : IReactiveElement
     LocalizedText _secondText;
     Image _fill;
 
-    public Experience(ExperienceState state)
+    public Leveling(LevelingState state)
     {
         _state = state;
     }
 
     public void Awake()
     {
-        if (CanvasService.ExperienceEnabled)
+        if (CanvasService.LevelingEnabled)
         {
             CanvasService.ConfigureHorizontalProgressBar(ref _barGameObject, ref _informationPanel,
-                ref _fill, ref _text, ref _header, CanvasService.Element.Experience, Color.green,
+                ref _fill, ref _text, ref _header, CanvasService.Element.Leveling, Color.green,
                 ref _firstText, ref _classText, ref _secondText);
         }
     }
@@ -37,11 +37,11 @@ internal class Experience : IReactiveElement
     {
         while (true)
         {
-            if (CanvasService.ExperienceEnabled)
+            if (CanvasService.LevelingEnabled)
             {
                 CanvasService.UpdateBar(_state.Progress, _state.Level,
                     _state.MaxLevel, _state.Prestige,
-                    _text, _header, _fill, CanvasService.Element.Experience);
+                    _text, _header, _fill, CanvasService.Element.Leveling);
                 CanvasService.UpdateClass(_state.Class, _classText);
             }
             yield return CanvasService.Delay;

--- a/Services/Managers/LevelingManager.cs
+++ b/Services/Managers/LevelingManager.cs
@@ -2,16 +2,16 @@ using System.Collections;
 
 namespace Eclipse.Services.Managers;
 
-internal class ExperienceManager : IReactiveElement
+internal class LevelingManager : IReactiveElement
 {
     public void Awake()
     {
-        CanvasService.Experience?.Awake();
+        CanvasService.Leveling?.Awake();
     }
 
     public IEnumerator OnUpdate()
     {
-        return CanvasService.Experience?.OnUpdate() ?? Dummy();
+        return CanvasService.Leveling?.OnUpdate() ?? Dummy();
 
         static IEnumerator Dummy()
         {

--- a/States/LegacyState.cs
+++ b/States/LegacyState.cs
@@ -3,7 +3,7 @@ using Eclipse.Services;
 
 namespace Eclipse.States;
 
-internal class LegacyState : ExperienceState
+internal class LegacyState : LevelingState
 {
     internal string LegacyType { get; set; } = string.Empty;
     internal List<string> BonusStats { get; set; } = new();

--- a/States/LevelingState.cs
+++ b/States/LevelingState.cs
@@ -2,7 +2,7 @@ using Eclipse.Services;
 
 namespace Eclipse.States;
 
-internal class ExperienceState
+internal class LevelingState
 {
     internal float Progress { get; set; }
     internal int Level { get; set; }


### PR DESCRIPTION
## Summary
- expose `Leveling` state in `DataService`
- rename Experience state and manager to Leveling
- update canvas service references
- update docs to mention the leveling bar

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882d455da18832d9bfa80b2917ccca8