### PR TITLE
Fix index error in BloodStats update

### DIFF
--- a/Elements/States/LegacyState.cs
+++ b/Elements/States/LegacyState.cs
@@ -3,5 +3,5 @@ namespace Eclipse.Elements.States;
 internal class LegacyState : LevelingState
 {
     public string LegacyType { get; set; } = string.Empty;
-    public List<string> BonusStats { get; set; } = [];
+    public List<string> BonusStats { get; set; } = ["None", "None", "None"];
 }

--- a/Services/CanvasService.cs
+++ b/Services/CanvasService.cs
@@ -983,17 +983,19 @@ internal class CanvasService
     {
         if (_killSwitch) return;
 
-        for (int i = 0; i < 3; i++)
+        for (int i = 0; i < 3 && i < statTexts.Count; i++)
         {
-            if (bonusStats[i] != "None")
+            string stat = i < bonusStats.Count ? bonusStats[i] : "None";
+
+            if (stat != "None")
             {
                 if (!statTexts[i].enabled) statTexts[i].enabled = true;
                 if (!statTexts[i].gameObject.active) statTexts[i].gameObject.SetActive(true);
 
-                string statInfo = getStatInfo(bonusStats[i]);
+                string statInfo = getStatInfo(stat);
                 statTexts[i].ForceSet(statInfo);
             }
-            else if (bonusStats[i] == "None" && statTexts[i].enabled)
+            else if (statTexts[i].enabled)
             {
                 statTexts[i].ForceSet("");
                 statTexts[i].enabled = false;
@@ -1006,17 +1008,19 @@ internal class CanvasService
     {
         if (_killSwitch) return;
 
-        for (int i = 0; i < 3; i++)
+        for (int i = 0; i < 3 && i < statTexts.Count; i++)
         {
-            if (bonusStats[i] != "None")
+            string stat = i < bonusStats.Count ? bonusStats[i] : "None";
+
+            if (stat != "None")
             {
                 if (!statTexts[i].enabled) statTexts[i].enabled = true;
                 if (!statTexts[i].gameObject.active) statTexts[i].gameObject.SetActive(true);
 
-                string statInfo = getStatInfo(bonusStats[i]);
+                string statInfo = getStatInfo(stat);
                 statTexts[i].ForceSet(statInfo);
             }
-            else if (bonusStats[i] == "None" && statTexts[i].enabled)
+            else if (statTexts[i].enabled)
             {
                 statTexts[i].ForceSet("");
                 statTexts[i].enabled = false;


### PR DESCRIPTION
## Summary
- initialize `LegacyState.BonusStats` with 3 placeholders
- guard `CanvasService.UpdateBloodStats` against short bonus lists

## Testing
- `~/.dotnet/dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_688d057867c8832d84ab93b69b7bf578