### PR TITLE
[codex] Add stat metadata coverage warnings

### DIFF
--- a/Services/DataService.cs
+++ b/Services/DataService.cs
@@ -1,6 +1,7 @@
 ﻿using Eclipse.Utilities;
 using Stunlock.Core;
 using System.Globalization;
+using System.Text;
 using UnityEngine;
 using static Eclipse.Services.CanvasService.DataHUD;
 
@@ -413,6 +414,7 @@ internal static class DataService
             _bloodStatValues = parsedConfigData.BloodStatValues;
 
             _classStatSynergies = parsedConfigData.ClassStatSynergies;
+            ValidateStatMetadataCoverage();
 
             try
             {
@@ -427,6 +429,91 @@ internal static class DataService
         {
             Core.Log.LogWarning($"Failed to parse config data: {ex}");
         }
+    }
+    static void ValidateStatMetadataCoverage()
+    {
+        ValidateStatCoverage(
+            "Weapon",
+            WeaponStatTypeAbbreviations,
+            WeaponStatStringAbbreviations,
+            WeaponStatFormats,
+            _weaponStatValues);
+
+        ValidateStatCoverage(
+            "Blood",
+            BloodStatTypeAbbreviations,
+            BloodStatStringAbbreviations,
+            null,
+            _bloodStatValues);
+
+        List<string> invalidWeaponSynergies = [];
+        List<string> invalidBloodSynergies = [];
+
+        foreach (var synergy in _classStatSynergies)
+        {
+            foreach (WeaponStatType stat in synergy.Value.WeaponStats)
+            {
+                if (stat == WeaponStatType.None || !Enum.IsDefined(typeof(WeaponStatType), stat))
+                {
+                    invalidWeaponSynergies.Add($"{synergy.Key}:{stat}");
+                }
+            }
+
+            foreach (BloodStatType stat in synergy.Value.BloodStats)
+            {
+                if (stat == BloodStatType.None || !Enum.IsDefined(typeof(BloodStatType), stat))
+                {
+                    invalidBloodSynergies.Add($"{synergy.Key}:{stat}");
+                }
+            }
+        }
+
+        LogStatMetadataWarning("Class synergies contain invalid weapon stats", invalidWeaponSynergies);
+        LogStatMetadataWarning("Class synergies contain invalid blood stats", invalidBloodSynergies);
+    }
+    static void ValidateStatCoverage<TStat>(
+        string label,
+        IReadOnlyDictionary<TStat, string> typeAbbreviations,
+        IReadOnlyDictionary<string, string> stringAbbreviations,
+        IReadOnlyDictionary<TStat, string> formats,
+        IReadOnlyDictionary<TStat, float> configuredValues)
+        where TStat : struct, Enum
+    {
+        List<TStat> stats = [.. Enum.GetValues<TStat>().Where(stat => !stat.ToString().Equals("None", StringComparison.Ordinal))];
+
+        LogStatMetadataWarning(
+            $"{label} stats missing type abbreviations",
+            [.. stats.Where(stat => !typeAbbreviations.ContainsKey(stat)).Select(stat => stat.ToString())]);
+
+        LogStatMetadataWarning(
+            $"{label} stats missing string abbreviations",
+            [.. stats.Where(stat => !stringAbbreviations.ContainsKey(stat.ToString())).Select(stat => stat.ToString())]);
+
+        if (formats != null)
+        {
+            LogStatMetadataWarning(
+                $"{label} stats missing formats",
+                [.. stats.Where(stat => !formats.ContainsKey(stat)).Select(stat => stat.ToString())]);
+        }
+
+        LogStatMetadataWarning(
+            $"{label} stats missing configured values",
+            [.. stats.Where(stat => !configuredValues.ContainsKey(stat)).Select(stat => stat.ToString())]);
+    }
+    static void LogStatMetadataWarning(string category, IReadOnlyCollection<string> missingItems)
+    {
+        if (missingItems.Count == 0)
+        {
+            return;
+        }
+
+        StringBuilder warning = new();
+        warning.Append("[DataService] Stat metadata coverage warning: ");
+        warning.Append(category);
+        warning.Append(" - ");
+        warning.Append(string.Join(", ", missingItems));
+
+        Core.Log.LogWarning(warning.ToString());
     }
     public static void ParsePlayerData(List<string> playerData)
     {


### PR DESCRIPTION
## Summary

Adds a narrow metadata coverage guardrail inside `DataService` after config parsing assigns weapon stat values, blood stat values, and class synergies.

## Issue

The stat metadata surfaces can drift independently: enum values, abbreviation dictionaries, configured stat values, weapon stat formats, and class synergy payloads are maintained in separate places. When one side changes without the matching metadata, the first visible symptom can be downstream display or config behavior rather than an early, consolidated warning.

## Cause and effect

`ParseConfigData` parsed and assigned the config-derived stat values but did not check whether every non-`None` weapon/blood stat had the expected metadata coverage. That made missing metadata easy to miss during future stat additions or config updates.

## Fix

- Runs `ValidateStatMetadataCoverage()` after config parsing assigns weapon values, blood values, and class synergies.
- Checks weapon stat type abbreviations, string abbreviations, formats, and configured values.
- Checks blood stat type abbreviations, string abbreviations, and configured values.
- Logs consolidated `[DataService] Stat metadata coverage warning:` messages for missing coverage and invalid class synergy stat entries.

## Non-goals

- No Canvas/HUD formatting changes.
- No enum value, abbreviation, config schema, or formatter-helper changes.
- No build-system changes in this PR.

## Verification

- `git diff --check` passed with only the expected CRLF working-copy warning.
- Static search found no `BloodStatFormats`, `FormatBloodStatBar`, `FormatBlood`, or formatter-helper additions.
- `dotnet build Eclipse.sln` passed with 0 warnings and 0 errors.

## Follow-up note

A later build hygiene PR could make the current `BuildToClient` post-build copy opt-in, for example with `-p:DeployToClient=true` and a configurable client plugin directory. I intentionally kept that out of this guardrail PR.