### PR TITLE
[codex] Add opt-in Emberglass bridge

### DIFF
--- a/.codex/scripts/version-metadata.sh
+++ b/.codex/scripts/version-metadata.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+CSPROJ_PATH="$REPO_ROOT/Eclipse.csproj"
+THUNDERSTORE_PATH="$REPO_ROOT/thunderstore.toml"
+CHANGELOG_PATH="$REPO_ROOT/CHANGELOG.md"
+CANONICAL_VERSION_PATTERN='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+fail() {
+    local message="$1"
+    echo "Error: $message" >&2
+    exit 1
+}
+
+read_csproj_version() {
+    local version
+    version=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' "$CSPROJ_PATH" | head -n 1 | tr -d '[:space:]')
+
+    if [ -z "$version" ]; then
+        fail "Unable to determine canonical version from $CSPROJ_PATH."
+    fi
+
+    printf '%s\n' "$version"
+}
+
+read_thunderstore_version() {
+    local version
+    version=$(sed -n 's/^versionNumber = "\([^"]*\)"$/\1/p' "$THUNDERSTORE_PATH" | head -n 1 | tr -d '[:space:]')
+
+    if [ -z "$version" ]; then
+        fail "Unable to determine Thunderstore version from $THUNDERSTORE_PATH."
+    fi
+
+    printf '%s\n' "$version"
+}
+
+read_latest_changelog_entry() {
+    local entry
+    # sed needs literal backticks to match the repo's changelog header format.
+    entry=$(sed -n '/^`[^`][^`]*`$/ { s/^`//; s/`$//; p; q; }' "$CHANGELOG_PATH" | tr -d '\r')
+
+    if [ -z "$entry" ]; then
+        fail "Unable to determine the latest CHANGELOG entry from $CHANGELOG_PATH."
+    fi
+
+    printf '%s\n' "$entry"
+}
+
+validate_canonical_version_format() {
+    local version="$1"
+    local source_name="$2"
+
+    if [[ ! "$version" =~ $CANONICAL_VERSION_PATTERN ]]; then
+        fail "$source_name version '$version' must match canonical format X.Y.Z."
+    fi
+}
+
+require_matching_version() {
+    local source_name="$1"
+    local source_version="$2"
+    local canonical_version="$3"
+
+    validate_canonical_version_format "$source_version" "$source_name"
+
+    if [ "$source_version" != "$canonical_version" ]; then
+        fail "$source_name version '$source_version' does not match canonical version '$canonical_version' from $CSPROJ_PATH."
+    fi
+}
+
+emit_canonical_version() {
+    local canonical_version="$1"
+
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        echo "canonical_version=$canonical_version" >> "$GITHUB_OUTPUT"
+    fi
+
+    echo "canonical_version=$canonical_version"
+}
+
+canonical_version=$(read_csproj_version)
+validate_canonical_version_format "$canonical_version" "$CSPROJ_PATH"
+
+require_matching_version "$THUNDERSTORE_PATH" "$(read_thunderstore_version)" "$canonical_version"
+require_matching_version "$CHANGELOG_PATH latest entry" "$(read_latest_changelog_entry)" "$canonical_version"
+
+emit_canonical_version "$canonical_version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,13 @@
 name: Build
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
+      - codex/feature-testing
   workflow_dispatch:
 
 concurrency:
@@ -11,14 +15,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  preflight:
+  validate_build_inputs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.check_release.outputs.should_build }}
       reason: ${{ steps.check_release.outputs.reason }}
-      version: ${{ steps.read_version.outputs.version }}
+      canonical_version: ${{ steps.version_metadata.outputs.canonical_version }}
       matched_tag: ${{ steps.check_release.outputs.matched_tag }}
       csproj_file: ${{ steps.discover_csproj.outputs.csproj_file }}
 
@@ -28,9 +32,11 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: false
+          persist-credentials: false
 
       - name: Discover .csproj
         id: discover_csproj
+        shell: bash
         run: |
           csproj_file=$(find . -type f -name '*.csproj' \
             -not -path '*/bin/*' \
@@ -44,26 +50,16 @@ jobs:
 
           echo "csproj_file=$csproj_file" >> "$GITHUB_OUTPUT"
 
-      - name: Read version from .csproj
-        id: read_version
+      - name: Validate canonical version metadata
+        id: version_metadata
         shell: bash
-        run: |
-          csproj='${{ steps.discover_csproj.outputs.csproj_file }}'
-          version=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' "$csproj" | head -n 1 | tr -d '[:space:]')
-
-          if [ -z "$version" ]; then
-            echo "Unable to determine current version from $csproj." >&2
-            exit 1
-          fi
-
-          echo "Current .csproj version: $version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+        run: bash .codex/scripts/version-metadata.sh
 
       - name: Check release tags for current version
         id: check_release
         uses: actions/github-script@v7
         env:
-          CURRENT_VERSION: ${{ steps.read_version.outputs.version }}
+          CURRENT_VERSION: ${{ steps.version_metadata.outputs.canonical_version }}
         with:
           script: |
             const currentVersion = process.env.CURRENT_VERSION;
@@ -73,8 +69,8 @@ jobs:
               return;
             }
 
-            if (context.eventName === 'workflow_dispatch') {
-              const reason = `Manual dispatch for version ${currentVersion}; allowing build.`;
+            if (context.eventName !== 'push') {
+              const reason = `Running validation-only workflow for ${context.eventName}; allowing build verification for canonical version ${currentVersion}.`;
               core.info(reason);
               core.setOutput('should_build', 'true');
               core.setOutput('reason', reason);
@@ -82,7 +78,15 @@ jobs:
               return;
             }
 
-            // Skip push builds when the current package version already exists in repository releases, including prereleases.
+            if (context.ref === 'refs/heads/codex/feature-testing') {
+              const reason = `Feature-testing branch snapshot derived from canonical version ${currentVersion}; allowing build.`;
+              core.info(reason);
+              core.setOutput('should_build', 'true');
+              core.setOutput('reason', reason);
+              core.setOutput('matched_tag', '');
+              return;
+            }
+
             const releases = await github.paginate(github.rest.repos.listReleases, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -112,93 +116,242 @@ jobs:
             core.setOutput('reason', reason);
             core.setOutput('matched_tag', '');
 
-  build:
-    needs: preflight
-    if: needs.preflight.outputs.should_build == 'true'
+  build_verification:
+    needs:
+      - validate_build_inputs
+    if: needs.validate_build_inputs.outputs.should_build == 'true'
     permissions:
-      contents: write
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
-      - name: Log preflight decision
+      - name: Log validation decision
+        shell: bash
         run: |
-          echo "Preflight decision: ${{ needs.preflight.outputs.should_build }}"
-          echo "Reason: ${{ needs.preflight.outputs.reason }}"
-          echo "Version: ${{ needs.preflight.outputs.version }}"
-          echo "Matched release tag: ${{ needs.preflight.outputs.matched_tag || 'none' }}"
+          echo "Validation decision: ${{ needs.validate_build_inputs.outputs.should_build }}"
+          echo "Reason: ${{ needs.validate_build_inputs.outputs.reason }}"
+          echo "Canonical version: ${{ needs.validate_build_inputs.outputs.canonical_version }}"
+          echo "Matched release tag: ${{ needs.validate_build_inputs.outputs.matched_tag || 'none' }}"
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
           fetch-tags: false
-
-      - name: Discover .csproj
-        id: discover_csproj
-        run: |
-          echo "csproj_file=${{ needs.preflight.outputs.csproj_file }}" >> "$GITHUB_OUTPUT"
-
-      - name: Get DLL name
-        id: get_dll_name
-        run: |
-          csproj="${{ steps.discover_csproj.outputs.csproj_file }}"
-          dll_name=$(basename "$csproj" .csproj)
-          echo "dll_name=$dll_name" >> "$GITHUB_OUTPUT"
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
+
+      - name: Validate canonical version metadata
+        shell: bash
+        run: bash .codex/scripts/version-metadata.sh
+
+      - name: Verify canonical files remain unchanged
+        shell: bash
+        run: |
+          csproj='${{ needs.validate_build_inputs.outputs.csproj_file }}'
+          git diff --exit-code -- "$csproj" thunderstore.toml CHANGELOG.md
 
       - name: Restore dependencies
-        run: dotnet restore
+        shell: bash
+        run: dotnet restore '${{ needs.validate_build_inputs.outputs.csproj_file }}'
 
-      - name: Update thunderstore.toml
+      - name: Build validation artifact
+        shell: bash
         run: |
-          version='${{ needs.preflight.outputs.version }}'
+          version='${{ needs.validate_build_inputs.outputs.canonical_version }}'
+          dotnet build '${{ needs.validate_build_inputs.outputs.csproj_file }}' \
+            --configuration Release \
+            --no-restore \
+            -p:Version="$version" \
+            -p:DeployToClient=false
 
-          if [ -z "$version" ]; then
-            echo "Version is empty; skipping thunderstore.toml update."
-            exit 0
-          fi
+  prepare_prerelease:
+    needs:
+      - validate_build_inputs
+      - build_verification
+    if: >-
+      github.event_name == 'push' &&
+      needs.validate_build_inputs.outputs.should_build == 'true' &&
+      github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      prerelease_version: ${{ steps.prepare_version.outputs.prerelease_version }}
+      prerelease_tag: ${{ steps.prepare_version.outputs.prerelease_tag }}
+      prerelease_name: ${{ steps.prepare_version.outputs.prerelease_name }}
 
-          sed -i "s/versionNumber = \".*\"/versionNumber = \"$version\"/" thunderstore.toml
-
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-
-          if [ -n "$(git status --porcelain thunderstore.toml)" ]; then
-            git add thunderstore.toml
-            git commit -m "chore: Update thunderstore.toml version to $version"
-            git push origin HEAD:${{ github.ref }}
-          else
-            echo "No changes to commit in thunderstore.toml"
-          fi
-
-      - name: Build (Release)
+    steps:
+      - name: Prepare prerelease metadata
+        id: prepare_version
+        shell: bash
         run: |
-          version='${{ needs.preflight.outputs.version }}'
+          canonical_version='${{ needs.validate_build_inputs.outputs.canonical_version }}'
 
-          if [ -n "$version" ]; then
-            dotnet build . --configuration Release -p:Version=$version -p:RunGenerateREADME=false
-          else
-            dotnet build . --configuration Release -p:RunGenerateREADME=false
+          if [ -z "$canonical_version" ]; then
+            echo "Canonical version is empty; cannot prepare prerelease metadata." >&2
+            exit 1
           fi
+
+          echo "prerelease_version=$canonical_version" >> "$GITHUB_OUTPUT"
+          echo "prerelease_tag=v${canonical_version}-pre" >> "$GITHUB_OUTPUT"
+          echo "prerelease_name=Pre-release v${canonical_version}" >> "$GITHUB_OUTPUT"
+
+  publish_prerelease:
+    needs:
+      - validate_build_inputs
+      - build_verification
+      - prepare_prerelease
+    if: >-
+      github.event_name == 'push' &&
+      needs.validate_build_inputs.outputs.should_build == 'true' &&
+      github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Validate canonical version metadata
+        shell: bash
+        run: bash .codex/scripts/version-metadata.sh
+
+      - name: Restore dependencies
+        shell: bash
+        run: dotnet restore '${{ needs.validate_build_inputs.outputs.csproj_file }}'
+
+      - name: Build prerelease artifact
+        shell: bash
+        run: |
+          version='${{ needs.prepare_prerelease.outputs.prerelease_version }}'
+          dotnet build '${{ needs.validate_build_inputs.outputs.csproj_file }}' \
+            --configuration Release \
+            --no-restore \
+            -p:Version="$version" \
+            -p:DeployToClient=false
 
       - name: GH Release (pre-release)
-        uses: softprops/action-gh-release@v1
-        if: needs.preflight.outputs.version != ''
+        uses: softprops/action-gh-release@v2.6.2
+        if: needs.prepare_prerelease.outputs.prerelease_version != ''
         with:
           body: |
-            Automated pre-release for version ${{ needs.preflight.outputs.version }} generated from this GitHub Actions build.
+            Automated pre-release for version ${{ needs.prepare_prerelease.outputs.prerelease_version }} generated from the main branch.
+            - Branch: ${{ github.ref_name }}
             - Commit: ${{ github.sha }}
             - Run: ${{ github.run_id }}
-          name: Pre-release v${{ needs.preflight.outputs.version }}
+          name: ${{ needs.prepare_prerelease.outputs.prerelease_name }}
           fail_on_unmatched_files: true
           prerelease: true
-          tag_name: v${{ needs.preflight.outputs.version }}-pre
+          tag_name: ${{ needs.prepare_prerelease.outputs.prerelease_tag }}
           files: |
-            ./bin/Release/net6.0/${{ steps.get_dll_name.outputs.dll_name }}.dll
+            ./bin/Release/net6.0/Eclipse.dll
+            CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  prepare_feature_testing_prerelease:
+    needs:
+      - validate_build_inputs
+      - build_verification
+    if: >-
+      github.event_name == 'push' &&
+      needs.validate_build_inputs.outputs.should_build == 'true' &&
+      github.ref == 'refs/heads/codex/feature-testing'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      feature_testing_version: ${{ steps.derive_version.outputs.feature_testing_version }}
+
+    steps:
+      - name: Derive feature-testing version
+        id: derive_version
+        shell: bash
+        run: |
+          canonical_version='${{ needs.validate_build_inputs.outputs.canonical_version }}'
+
+          if [ -z "$canonical_version" ]; then
+            echo "Canonical version is empty; cannot derive feature-testing version." >&2
+            exit 1
+          fi
+
+          feature_testing_version="${canonical_version}-ft.${GITHUB_RUN_NUMBER}"
+
+          echo "Derived feature-testing version: $feature_testing_version"
+          echo "feature_testing_version=$feature_testing_version" >> "$GITHUB_OUTPUT"
+
+  publish_feature_testing_prerelease:
+    needs:
+      - validate_build_inputs
+      - build_verification
+      - prepare_feature_testing_prerelease
+    if: >-
+      github.event_name == 'push' &&
+      needs.validate_build_inputs.outputs.should_build == 'true' &&
+      github.ref == 'refs/heads/codex/feature-testing'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore dependencies
+        shell: bash
+        run: dotnet restore '${{ needs.validate_build_inputs.outputs.csproj_file }}'
+
+      - name: Build feature-testing artifact
+        shell: bash
+        run: |
+          feature_testing_version='${{ needs.prepare_feature_testing_prerelease.outputs.feature_testing_version }}'
+          dotnet build '${{ needs.validate_build_inputs.outputs.csproj_file }}' \
+            --configuration Release \
+            --no-restore \
+            -p:Version="$feature_testing_version" \
+            -p:DeployToClient=false
+
+      - name: GH Release (feature-testing snapshot)
+        uses: softprops/action-gh-release@v2.6.2
+        if: needs.prepare_feature_testing_prerelease.outputs.feature_testing_version != ''
+        with:
+          body: |
+            Disposable feature-testing branch snapshot for validation and smoke testing only.
+            - Snapshot version: ${{ needs.prepare_feature_testing_prerelease.outputs.feature_testing_version }}
+            - Canonical version: ${{ needs.validate_build_inputs.outputs.canonical_version }}
+            - Branch: ${{ github.ref_name }}
+            - Commit: ${{ github.sha }}
+            - Run: ${{ github.run_id }}
+          name: feature-testing prerelease v${{ needs.prepare_feature_testing_prerelease.outputs.feature_testing_version }}
+          fail_on_unmatched_files: true
+          prerelease: true
+          tag_name: v${{ needs.prepare_feature_testing_prerelease.outputs.feature_testing_version }}
+          files: |
+            ./bin/Release/net6.0/Eclipse.dll
             CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,44 +2,102 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing GitHub Release tag to publish to Thunderstore, such as v1.3.13 or v1.3.13-pre.
+        required: true
+        type: string
 
 jobs:
   release_on_thunderstore:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '6.0.x'
-          dotnet-quality: 'preview'
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Extract Latest Tag
-        id: extract_tag
-        run: |
-          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
-          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
+      - name: Validate canonical version metadata
+        id: version_metadata
         shell: bash
+        run: bash .codex/scripts/version-metadata.sh
 
-      - name: Set Release Tag
-        run: echo "RELEASE_TAG=${{ env.latest_tag }}" >> $GITHUB_ENV
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Select eligible release tag
+        id: select_tag
+        shell: bash
+        run: |
+          canonical_version='${{ steps.version_metadata.outputs.canonical_version }}'
+          requested_tag='${{ inputs.release_tag }}'
+
+          allowed_tag_pattern='^v[0-9]+\.[0-9]+\.[0-9]+(-pre)?$'
+          allowed_package_version_pattern='^[0-9]+\.[0-9]+\.[0-9]+(-pre)?$'
+
+          if [[ -z "$requested_tag" ]]; then
+            echo "Error: release_tag input is required." >&2
+            exit 1
+          fi
+
+          if [[ ! "$requested_tag" =~ $allowed_tag_pattern ]]; then
+            echo "Error: Release tag '$requested_tag' is not an allowed Thunderstore source tag." >&2
+            echo "Expected one of: vX.Y.Z or vX.Y.Z-pre." >&2
+            exit 1
+          fi
+
+          if ! git rev-parse -q --verify "refs/tags/$requested_tag" >/dev/null; then
+            echo "Error: Release tag '$requested_tag' was not found in this checkout." >&2
+            exit 1
+          fi
+
+          package_version="${requested_tag#v}"
+
+          if [[ "$package_version" != "$canonical_version" && "$package_version" != "$canonical_version-pre" ]]; then
+            echo "Error: Release tag '$requested_tag' does not align with canonical version '$canonical_version'." >&2
+            exit 1
+          fi
+
+          echo "Selected Thunderstore tag: $requested_tag"
+          echo "Thunderstore package version: $package_version"
+
+          echo "RELEASE_TAG=$requested_tag" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERSION=$package_version" >> "$GITHUB_ENV"
+          echo "ALLOWED_TAG_PATTERN=$allowed_tag_pattern" >> "$GITHUB_ENV"
+          echo "ALLOWED_PACKAGE_VERSION_PATTERN=$allowed_package_version_pattern" >> "$GITHUB_ENV"
 
       - name: Download Release
-        run: |
-          gh release download ${{ env.RELEASE_TAG }} -D ./dist
+        run: gh release download "$RELEASE_TAG" -D ./dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
 
-      - name: Install Thunderstore CLI (tcli)
+      - name: Install Thunderstore CLI
         run: dotnet tool install --global tcli
 
       - name: Publish build to Thunderstore
+        shell: bash
         run: |
-          trimmed_tag=${RELEASE_TAG:1}
-          tcli publish --token ${{ secrets.THUNDERSTORE_KEY }} --package-version $trimmed_tag
+          if [[ ! $RELEASE_TAG =~ $ALLOWED_TAG_PATTERN ]]; then
+            echo "Error: Release tag '$RELEASE_TAG' is not an allowed Thunderstore source tag." >&2
+            exit 1
+          fi
+
+          if [[ ! $PACKAGE_VERSION =~ $ALLOWED_PACKAGE_VERSION_PATTERN ]]; then
+            echo "Error: Package version '$PACKAGE_VERSION' derived from '$RELEASE_TAG' is not an allowed Thunderstore package version." >&2
+            exit 1
+          fi
+
+          echo "Publishing Thunderstore package version: $PACKAGE_VERSION"
+          tcli publish --token "$THUNDERSTORE_KEY" --package-version "$PACKAGE_VERSION"
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          PACKAGE_VERSION: ${{ env.PACKAGE_VERSION }}
+          ALLOWED_TAG_PATTERN: ${{ env.ALLOWED_TAG_PATTERN }}
+          ALLOWED_PACKAGE_VERSION_PATTERN: ${{ env.ALLOWED_PACKAGE_VERSION_PATTERN }}
+          THUNDERSTORE_KEY: ${{ secrets.THUNDERSTORE_KEY }}

--- a/BloodcraftEclipseBridge/Messages/EclipseRegistrationPacket.cs
+++ b/BloodcraftEclipseBridge/Messages/EclipseRegistrationPacket.cs
@@ -1,0 +1,15 @@
+namespace BloodcraftEclipseBridge.Messages;
+
+internal sealed class EclipseRegistrationPacket
+{
+    public string Message { get; set; } = string.Empty;
+
+    public EclipseRegistrationPacket()
+    {
+    }
+
+    public EclipseRegistrationPacket(string message)
+    {
+        Message = message;
+    }
+}

--- a/BloodcraftEclipseBridge/Messages/EclipseServerMessagePacket.cs
+++ b/BloodcraftEclipseBridge/Messages/EclipseServerMessagePacket.cs
@@ -1,0 +1,15 @@
+namespace BloodcraftEclipseBridge.Messages;
+
+internal sealed class EclipseServerMessagePacket
+{
+    public string Message { get; set; } = string.Empty;
+
+    public EclipseServerMessagePacket()
+    {
+    }
+
+    public EclipseServerMessagePacket(string message)
+    {
+        Message = message;
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+`1.3.14`
+- optional Emberglass bridge support for Bloodcraft registration and server messages
+- release workflow hardening for safer prerelease and Thunderstore publishing
+
 `1.3.13`
 - primal weapons
 

--- a/Eclipse.csproj
+++ b/Eclipse.csproj
@@ -4,7 +4,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<BepInExPluginGuid>io.zfolmt.Eclipse</BepInExPluginGuid>
 		<AssemblyName>Eclipse</AssemblyName>
-		<Version>1.3.13</Version>
+		<Version>1.3.14</Version>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 		<LangVersion>preview</LangVersion>

--- a/Patches/ClientChatSystemPatch.cs
+++ b/Patches/ClientChatSystemPatch.cs
@@ -99,30 +99,9 @@ internal static class ClientChatSystemPatch
                     ChatMessageServerEvent chatMessage = entity.Read<ChatMessageServerEvent>();
                     string message = chatMessage.MessageText.Value;
 
-                    if (chatMessage.MessageType.Equals(ServerChatMessageType.System) && CheckMAC(message, out string originalMessage))
+                    if (chatMessage.MessageType.Equals(ServerChatMessageType.System) && TryHandleBridgeServerMessage(message, out _))
                     {
-                        HandleServerMessage(originalMessage);
                         EntityManager.DestroyEntity(entity);
-
-                        try
-                        {
-                            ShadowMatter.OnLoad();
-                        }
-                        catch (Exception ex)
-                        {
-                            Core.Log.LogWarning($"{ex}");
-                        }
-
-                        /*
-                        try
-                        {
-                            ShadowMatter.LoadAssets();
-                        }
-                        catch (Exception ex)
-                        {
-                            Core.Log.LogWarning($"{ex}");
-                        }
-                        */
                     }
                 }
             }
@@ -155,6 +134,11 @@ internal static class ClientChatSystemPatch
 
         if (string.IsNullOrEmpty(messageWithMAC)) return;
 
+        if (EmberglassEclipseBridge.TrySendRegistration(messageWithMAC))
+        {
+            return;
+        }
+
         ChatMessageEvent chatMessageEvent = new()
         {
             MessageText = new FixedString512Bytes(messageWithMAC),
@@ -167,7 +151,47 @@ internal static class ClientChatSystemPatch
         networkEntity.Write(_networkEventType);
         networkEntity.Write(chatMessageEvent);
 
-        Core.Log.LogInfo($"Registration payload sent to server ({DateTime.Now}) - {messageWithMAC}");
+        Core.Log.LogInfo($"Registration payload sent to server via ChatMessage ({DateTime.Now})");
+    }
+    internal static bool TryHandleBridgeServerMessage(string message, out string messageKind)
+    {
+        messageKind = "server message";
+
+        if (!CheckMAC(message, out string originalMessage))
+        {
+            return false;
+        }
+
+        messageKind = GetMessageKind(originalMessage);
+        HandleServerMessage(originalMessage);
+        TryLoadShadowMatter();
+
+        return true;
+    }
+    static string GetMessageKind(string message)
+    {
+        if (!int.TryParse(_regexExtract.Match(message).Groups[1].Value, out int result))
+        {
+            return "server message";
+        }
+
+        return result switch
+        {
+            (int)NetworkEventSubType.ProgressToClient => "progress",
+            (int)NetworkEventSubType.ConfigsToClient => "configs",
+            _ => "server message"
+        };
+    }
+    static void TryLoadShadowMatter()
+    {
+        try
+        {
+            ShadowMatter.OnLoad();
+        }
+        catch (Exception ex)
+        {
+            Core.Log.LogWarning($"{ex}");
+        }
     }
     static void HandleServerMessage(string message)
     {
@@ -230,7 +254,7 @@ internal static class ClientChatSystemPatch
             }
             else
             {
-                Core.Log.LogInfo($"MAC verification failed for matched RegEx message - {receivedMessage}");
+                Core.Log.LogInfo("MAC verification failed for matched RegEx server message.");
             }
         }
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -2,6 +2,7 @@ using BepInEx;
 using BepInEx.Configuration;
 using BepInEx.Logging;
 using BepInEx.Unity.IL2CPP;
+using Eclipse.Services;
 using HarmonyLib;
 using System.Reflection;
 using UnityEngine;
@@ -9,6 +10,7 @@ using UnityEngine;
 namespace Eclipse;
 
 [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
+[BepInDependency("io.zfolmt.Emberglass", BepInDependency.DependencyFlags.SoftDependency)]
 internal class Plugin : BasePlugin
 {
     Harmony _harmony;
@@ -25,6 +27,7 @@ internal class Plugin : BasePlugin
     static ConfigEntry<bool> _quests;
     static ConfigEntry<bool> _shiftSlot;
     static ConfigEntry<bool> _eclipsed;
+    static ConfigEntry<bool> _useEmberglassBridge;
     public static bool Leveling
         => _leveling.Value;
     public static bool Prestige
@@ -43,6 +46,8 @@ internal class Plugin : BasePlugin
         => _shiftSlot.Value;
     public static bool Eclipsed
         => _eclipsed.Value;
+    public static bool UseEmberglassBridge
+        => _useEmberglassBridge.Value;
     public override void Load()
     {
         Instance = this;
@@ -55,6 +60,7 @@ internal class Plugin : BasePlugin
 
         _harmony = Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly());
         InitConfig();
+        EmberglassEclipseBridge.Initialize();
         Core.Log.LogInfo($"{MyPluginInfo.PLUGIN_NAME}[{MyPluginInfo.PLUGIN_VERSION}] loaded on client!");
     }
     static void InitConfig()
@@ -68,6 +74,7 @@ internal class Plugin : BasePlugin
         _quests = InitConfigEntry("UIOptions", "QuestTrackers", true, "Enable/Disable the quest tracker, requires both ClientCompanion/QuestSystem to be enabled in Bloodcraft.");
         _shiftSlot = InitConfigEntry("UIOptions", "ShiftSlot", true, "Enable/Disable the shift slot, requires both ClientCompanion and shift slot spell to be enabled in Bloodcraft.");
         _eclipsed = InitConfigEntry("UIOptions", "Eclipsed", true, "Set to false for slower update intervals (0.1s -> 1s) if performance is negatively impacted.");
+        _useEmberglassBridge = InitConfigEntry("UIOptions", "UseEmberglassBridge", false, "Use Emberglass for the Bloodcraft/Eclipse bridge when Emberglass is installed. Falls back to the legacy chat bridge when disabled or unavailable.");
     }
     static ConfigEntry<T> InitConfigEntry<T>(string section, string key, T defaultValue, string description)
     {

--- a/Services/EmberglassEclipseBridge.cs
+++ b/Services/EmberglassEclipseBridge.cs
@@ -1,0 +1,191 @@
+using BloodcraftEclipseBridge.Messages;
+using Eclipse.Patches;
+using ProjectM.Network;
+using System.Reflection;
+
+namespace Eclipse.Services;
+
+internal static class EmberglassEclipseBridge
+{
+    const string EMBERGLASS_ASSEMBLY_NAME = "Emberglass";
+    const string VNETWORK_TYPE_NAME = "Emberglass.API.Shared.VNetwork";
+
+    static bool _initialized;
+    static bool _available;
+    static bool _clientReady;
+    static bool _disabledForSession;
+    static bool _unavailableLogged;
+    static bool _clientReadyLogged;
+    static string _pendingRegistrationMessage;
+    static MethodInfo _sendToServer;
+    static PropertyInfo _isReady;
+    static EventInfo _onReady;
+    static EventInfo _onClientReady;
+
+    public static void Initialize()
+    {
+        if (_initialized || !Plugin.UseEmberglassBridge || _disabledForSession)
+        {
+            return;
+        }
+
+        _initialized = true;
+
+        if (!TryResolveVNetwork(out Type vNetworkType))
+        {
+            LogUnavailable("Emberglass is not loaded");
+            return;
+        }
+
+        try
+        {
+            MethodInfo registerClientbound = GetGenericMethod(vNetworkType, "RegisterClientbound", 1);
+            _sendToServer = GetGenericMethod(vNetworkType, "SendToServer", 1);
+            _isReady = vNetworkType.GetProperty("IsReady", BindingFlags.Public | BindingFlags.Static);
+            _onReady = vNetworkType.GetEvent("OnReady", BindingFlags.Public | BindingFlags.Static);
+            _onClientReady = vNetworkType.GetEvent("OnClientReady", BindingFlags.Public | BindingFlags.Static);
+
+            registerClientbound
+                .MakeGenericMethod(typeof(EclipseServerMessagePacket))
+                .Invoke(null, [new Action<User, EclipseServerMessagePacket>(OnServerMessagePacket)]);
+
+            _onClientReady?.AddEventHandler(null, new Action(OnClientReady));
+
+            _available = true;
+            Core.Log.LogInfo("[EclipseBridge:Emberglass] registered");
+        }
+        catch (Exception ex)
+        {
+            DisableForSession($"failed to register bridge ({ex.GetType().Name}: {ex.Message})");
+        }
+    }
+
+    public static bool TrySendRegistration(string message)
+    {
+        if (!Plugin.UseEmberglassBridge || _disabledForSession)
+        {
+            return false;
+        }
+
+        Initialize();
+
+        if (!_available)
+        {
+            return false;
+        }
+
+        if (!IsClientReady())
+        {
+            _pendingRegistrationMessage = message;
+            Core.Log.LogInfo("[EclipseBridge:Emberglass] registration queued");
+            return true;
+        }
+
+        return TrySendRegistrationNow(message);
+    }
+
+    static bool TrySendRegistrationNow(string message)
+    {
+        try
+        {
+            _sendToServer
+                .MakeGenericMethod(typeof(EclipseRegistrationPacket))
+                .Invoke(null, [new EclipseRegistrationPacket(message)]);
+
+            Core.Log.LogInfo("[EclipseBridge:Emberglass] registration sent");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            DisableForSession($"failed to send registration ({ex.GetType().Name}: {ex.Message})");
+            return false;
+        }
+    }
+
+    static void OnServerMessagePacket(User sender, EclipseServerMessagePacket packet)
+    {
+        if (string.IsNullOrWhiteSpace(packet.Message))
+        {
+            Core.Log.LogWarning("[EclipseBridge:Emberglass] empty server message received");
+            return;
+        }
+
+        if (!ClientChatSystemPatch.TryHandleBridgeServerMessage(packet.Message, out string messageKind))
+        {
+            Core.Log.LogWarning("[EclipseBridge:Emberglass] failed to verify server message MAC");
+            return;
+        }
+
+        Core.Log.LogInfo($"[EclipseBridge:Emberglass] {messageKind} received");
+    }
+
+    static void OnClientReady()
+    {
+        _clientReady = true;
+
+        if (_clientReadyLogged)
+        {
+            return;
+        }
+
+        _clientReadyLogged = true;
+        Core.Log.LogInfo("[EclipseBridge:Emberglass] client ready");
+
+        if (string.IsNullOrEmpty(_pendingRegistrationMessage))
+        {
+            return;
+        }
+
+        string message = _pendingRegistrationMessage;
+        _pendingRegistrationMessage = string.Empty;
+        TrySendRegistrationNow(message);
+    }
+
+    static bool TryResolveVNetwork(out Type vNetworkType)
+    {
+        Assembly assembly = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .FirstOrDefault(loadedAssembly => loadedAssembly.GetName().Name == EMBERGLASS_ASSEMBLY_NAME);
+
+        vNetworkType = assembly?.GetType(VNETWORK_TYPE_NAME, throwOnError: false);
+        return vNetworkType != null;
+    }
+
+    static MethodInfo GetGenericMethod(Type declaringType, string name, int parameterCount)
+    {
+        return declaringType
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(method =>
+                method.Name == name
+                && method.IsGenericMethodDefinition
+                && method.GetParameters().Length == parameterCount);
+    }
+
+    static bool IsClientReady()
+    {
+        return _clientReady;
+    }
+
+    static bool IsReady()
+    {
+        return _isReady?.GetValue(null) is true;
+    }
+
+    static void LogUnavailable(string reason)
+    {
+        if (_unavailableLogged)
+        {
+            return;
+        }
+
+        _unavailableLogged = true;
+        Core.Log.LogInfo($"[EclipseBridge:Emberglass] unavailable; using ChatMessage bridge ({reason})");
+    }
+
+    static void DisableForSession(string reason)
+    {
+        _available = false;
+        _disabledForSession = true;
+        Core.Log.LogWarning($"[EclipseBridge:Emberglass] disabled for this session; using ChatMessage bridge ({reason})");
+    }
+}

--- a/Services/EmberglassEclipseBridge.cs
+++ b/Services/EmberglassEclipseBridge.cs
@@ -49,7 +49,8 @@ internal static class EmberglassEclipseBridge
                 .MakeGenericMethod(typeof(EclipseServerMessagePacket))
                 .Invoke(null, [new Action<User, EclipseServerMessagePacket>(OnServerMessagePacket)]);
 
-            _onClientReady?.AddEventHandler(null, new Action(OnClientReady));
+            SubscribeReadinessEvent(_onClientReady);
+            SubscribeReadinessEvent(_onReady);
 
             _available = true;
             Core.Log.LogInfo("[EclipseBridge:Emberglass] registered");
@@ -129,6 +130,53 @@ internal static class EmberglassEclipseBridge
 
         _clientReadyLogged = true;
         Core.Log.LogInfo("[EclipseBridge:Emberglass] client ready");
+    }
+
+    static void OnReady(User user)
+    {
+        OnClientReady();
+    }
+
+    static void SubscribeReadinessEvent(EventInfo readinessEvent)
+    {
+        if (readinessEvent?.EventHandlerType is not { } handlerType)
+        {
+            return;
+        }
+
+        MethodInfo handlerMethod = ResolveReadinessHandler(handlerType);
+        if (handlerMethod == null)
+        {
+            return;
+        }
+
+        readinessEvent.AddEventHandler(null, Delegate.CreateDelegate(handlerType, handlerMethod));
+    }
+
+    static MethodInfo ResolveReadinessHandler(Type handlerType)
+    {
+        MethodInfo invoke = handlerType.GetMethod("Invoke");
+        if (invoke?.ReturnType != typeof(void))
+        {
+            return null;
+        }
+
+        ParameterInfo[] parameters = invoke.GetParameters();
+        if (parameters.Length == 0)
+        {
+            return typeof(EmberglassEclipseBridge).GetMethod(
+                nameof(OnClientReady),
+                BindingFlags.Static | BindingFlags.NonPublic);
+        }
+
+        if (parameters.Length == 1 && parameters[0].ParameterType == typeof(User))
+        {
+            return typeof(EmberglassEclipseBridge).GetMethod(
+                nameof(OnReady),
+                BindingFlags.Static | BindingFlags.NonPublic);
+        }
+
+        return null;
     }
 
     static bool TryResolveVNetwork(out Type vNetworkType)

--- a/Services/EmberglassEclipseBridge.cs
+++ b/Services/EmberglassEclipseBridge.cs
@@ -16,7 +16,7 @@ internal static class EmberglassEclipseBridge
     static bool _disabledForSession;
     static bool _unavailableLogged;
     static bool _clientReadyLogged;
-    static string _pendingRegistrationMessage;
+    static bool _notReadyLogged;
     static MethodInfo _sendToServer;
     static PropertyInfo _isReady;
     static EventInfo _onReady;
@@ -76,9 +76,8 @@ internal static class EmberglassEclipseBridge
 
         if (!IsClientReady())
         {
-            _pendingRegistrationMessage = message;
-            Core.Log.LogInfo("[EclipseBridge:Emberglass] registration queued");
-            return true;
+            LogNotReady();
+            return false;
         }
 
         return TrySendRegistrationNow(message);
@@ -130,15 +129,6 @@ internal static class EmberglassEclipseBridge
 
         _clientReadyLogged = true;
         Core.Log.LogInfo("[EclipseBridge:Emberglass] client ready");
-
-        if (string.IsNullOrEmpty(_pendingRegistrationMessage))
-        {
-            return;
-        }
-
-        string message = _pendingRegistrationMessage;
-        _pendingRegistrationMessage = string.Empty;
-        TrySendRegistrationNow(message);
     }
 
     static bool TryResolveVNetwork(out Type vNetworkType)
@@ -163,7 +153,18 @@ internal static class EmberglassEclipseBridge
 
     static bool IsClientReady()
     {
-        return _clientReady;
+        if (_clientReady)
+        {
+            return true;
+        }
+
+        if (IsReady())
+        {
+            OnClientReady();
+            return true;
+        }
+
+        return false;
     }
 
     static bool IsReady()
@@ -180,6 +181,16 @@ internal static class EmberglassEclipseBridge
 
         _unavailableLogged = true;
         Core.Log.LogInfo($"[EclipseBridge:Emberglass] unavailable; using ChatMessage bridge ({reason})");
+    }
+    static void LogNotReady()
+    {
+        if (_notReadyLogged)
+        {
+            return;
+        }
+
+        _notReadyLogged = true;
+        Core.Log.LogInfo("[EclipseBridge:Emberglass] client not ready; using ChatMessage bridge");
     }
 
     static void DisableForSession(string reason)

--- a/thunderstore.toml
+++ b/thunderstore.toml
@@ -11,7 +11,7 @@ v-rising = ["oakveil-update", "mods", "client"]
 [package]
 namespace = "zfolmt"
 name = "Eclipse"
-versionNumber = "1.3.13"
+versionNumber = "1.3.14"
 description = "Client UI for Bloodcraft!"
 websiteUrl = "https://github.com/mfoltz/Eclipse"
 containsNsfwContent = false


### PR DESCRIPTION
## Summary

- Adds an Eclipse-side reflection-backed Emberglass bridge for the existing Bloodcraft/Eclipse signed payload flow.
- Keeps `UIOptions.UseEmberglassBridge` disabled by default and falls back to the legacy ChatMessage registration path when Emberglass is disabled, unavailable, or not client-ready.
- Receives Bloodcraft config/progress packets through Emberglass and reuses the existing MAC verification and server-message handling path.

## Validation

- `git diff --check`
- `dotnet build Eclipse.csproj --configuration Release -p:DeployToClient=false`: build succeeded with 0 warnings/errors

## Runtime Proof

The combined Bloodcraft/Eclipse enabled bridge proof was run with the committed Emberglass networking beta DLL and classified green.

- Emberglass proof commit: `bb5a122`
- Emberglass DLL SHA256: `FE4364C463DD8F42508C93441E66060361CC51E4C698883BB8D167CF6D772AB7`
- Consumer proof run id: `20260513-203324`
- Server markers: trust ready, handshake start received, key exchange offer sent, key exchange accepted, bridge registration received, configs sent, progress sent, no MAC/trust/truncation/startup failure markers.
- Client markers: pinned server key accepted, session key established, Eclipse bridge ready, registration sent, configs received, progress received, no MAC/trust/truncation/authentication failure markers.

## Notes

Bloodcraft server-side bridge changes live in the stacked Bloodcraft bridge PR. Emberglass public API/release work lives in the separate Emberglass PR.